### PR TITLE
chore: Tailwind CSS v4 테마 설정 및 피그마 디자인 토큰 적용 (#3)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,86 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
+@theme {
+  /* =====================
+     Breakpoints
+     Mobile: 360px (base, no prefix needed)
+     Tablet: 744px  → tablet:
+     Desktop: 1920px → desktop:
+  ===================== */
+  --breakpoint-tablet: 744px;
+  --breakpoint-desktop: 1920px;
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
+  /* =====================
+     Color — Black (neutral gray scale)
+  ===================== */
+  --color-black-100: #787878;
+  --color-black-200: #6b6b6b;
+  --color-black-300: #5e5e5e;
+  --color-black-400: #525252;
+  --color-black-500: #454545;
+  --color-black-600: #373737;
+  --color-black-700: #2b2b2b;
+  --color-black-800: #1f1f1f;
+  --color-black-900: #121212;
+  --color-black-950: #050505;
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  /* =====================
+     Color — Blue (brand primary)
+  ===================== */
+  --color-blue-100: #ffffff;
+  --color-blue-200: #eceff4;
+  --color-blue-300: #cbd3e1;
+  --color-blue-400: #abb8ce;
+  --color-blue-500: #8b9dbc;
+  --color-blue-600: #6a82a9;
+  --color-blue-700: #52698e;
+  --color-blue-800: #40516e;
+  --color-blue-900: #2d394e;
+  --color-blue-950: #1a212d;
+
+  /* =====================
+     Color — Gray
+  ===================== */
+  --color-gray-100: #dedede;
+  --color-gray-200: #c4c4c4;
+  --color-gray-300: #ababab;
+  --color-gray-400: #919191;
+
+  /* =====================
+     Color — Background
+  ===================== */
+  --color-background: #f5f7fa;
+
+  /* =====================
+     Color — Line (border)
+  ===================== */
+  --color-line-100: #f2f2f2;
+  --color-line-200: #cfdbea;
+
+  /* =====================
+     Color — State
+  ===================== */
+  --color-error: #ff6577;
+
+  /* =====================
+     Color — Illustration
+  ===================== */
+  --color-illust-yellow: #fbc85b;
+  --color-illust-green: #48bb98;
+  --color-illust-purple: #8e80e3;
+  --color-illust-blue: #5195ee;
+  --color-illust-red: #e46e80;
+  --color-illust-brown: #9a695e;
+  --color-sub-yellow: #e8aa26;
+  --color-sub-blue-1: #3e3e3e;
+  --color-sub-blue-2: #3e414d;
+  --color-sub-blue-3: #494d59;
+  --color-sub-gray-1: #c7d1e0;
+  --color-sub-gray-2: #e3e9f1;
+  --color-sub-gray-3: #eff3f8;
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  background-color: var(--color-background);
+  color: var(--color-black-600);
 }


### PR DESCRIPTION
## ✏️ 작업 내용

- 피그마 시안 기반 색상 토큰 전체를 Tailwind v4 `@theme`으로 등록
- 피그마 캔버스 기준 브레이크포인트 설정 (`tablet: 744px`, `desktop: 1920px`)
- 기존 Next.js 보일러플레이트(dark mode, Geist 폰트 변수) 제거

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 Tailwind CSS v4 테마 설정 및 피그마 디자인 토큰 적용 기능이 추가됩니다.

Closes #3