### PR TITLE
feat: User 엔티티 Zod 스키마 정의 (#47)

### DIFF
--- a/specs/001-epigram-core-pages/tasks.md
+++ b/specs/001-epigram-core-pages/tasks.md
@@ -61,7 +61,7 @@
 
 ### US1 — 엔티티 & 모델
 
-- [ ] T021 [P] [US1] User 엔티티 Zod 스키마 정의 (`src/entities/user/model/schema.ts`)
+- [x] T021 [P] [US1] User 엔티티 Zod 스키마 정의 (`src/entities/user/model/schema.ts`)
 - [ ] T022 [P] [US1] Auth 응답 타입 정의 — SignUpResponse, SignInResponse (`src/entities/user/model/types.ts`)
 
 ### US1 — API 레이어

--- a/src/entities/user/model/schema.ts
+++ b/src/entities/user/model/schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const userSchema = z.object({
+  id: z.number().int().positive(),
+  nickname: z.string().min(1).max(30),
+  email: z.string().email().optional(),
+  image: z.string().url().nullable(),
+  teamId: z.string(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export type User = z.infer<typeof userSchema>;


### PR DESCRIPTION
## ✏️ 작업 내용

- `userSchema`: id, nickname, email(optional), image(nullable), teamId, createdAt, updatedAt
- `User` 타입을 `z.infer<typeof userSchema>`로 추론

Closes #47

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 User 엔티티 Zod 스키마 정의 기능이 추가됩니다.

Closes #47