### PR TITLE
feat: 공용 UI 컴포넌트 피그마 시안 반영 (Input, Button)

### DIFF
--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -4,10 +4,11 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const VARIANT_CLASSES = {
-  primary: "bg-black text-white hover:bg-gray-800 disabled:bg-gray-300 disabled:cursor-not-allowed",
+  primary:
+    "bg-black-500 text-white hover:bg-black-600 disabled:bg-blue-300 disabled:text-white disabled:cursor-not-allowed",
   secondary:
-    "border border-black text-black hover:bg-gray-100 disabled:border-gray-300 disabled:text-gray-300 disabled:cursor-not-allowed",
-  ghost: "text-gray-500 hover:text-black disabled:text-gray-300 disabled:cursor-not-allowed",
+    "border border-black-500 text-black-500 hover:bg-blue-200 disabled:border-blue-300 disabled:text-blue-300 disabled:cursor-not-allowed",
+  ghost: "text-blue-400 hover:text-black-500 disabled:text-blue-300 disabled:cursor-not-allowed",
 } as const;
 
 export function Button({
@@ -21,7 +22,7 @@ export function Button({
   return (
     <button
       disabled={disabled || isLoading}
-      className={`inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black ${VARIANT_CLASSES[variant]} ${className}`}
+      className={`inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black-500 ${VARIANT_CLASSES[variant]} ${className}`}
       {...props}
     >
       {isLoading ? (

--- a/src/shared/ui/Input.tsx
+++ b/src/shared/ui/Input.tsx
@@ -7,20 +7,20 @@ export function Input({ label, error, id, className = "", ...props }: InputProps
   const inputId = id ?? label;
 
   return (
-    <div className="flex flex-col gap-1">
+    <div className="flex flex-col gap-2">
       {label ? (
-        <label htmlFor={inputId} className="text-sm font-medium text-gray-700">
+        <label htmlFor={inputId} className="text-sm font-medium text-blue-900">
           {label}
         </label>
       ) : null}
       <input
         id={inputId}
-        className={`rounded-lg border px-4 py-2 text-sm outline-none transition-colors placeholder:text-gray-400 focus:ring-2 focus:ring-black disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400 ${
-          error ? "border-red-500 focus:ring-red-500" : "border-gray-300 focus:border-black"
+        className={`h-11 w-full rounded-xl bg-blue-200 px-4 text-sm text-black-950 outline-none transition-colors placeholder:text-blue-400 focus:ring-2 focus:ring-black-500 disabled:cursor-not-allowed disabled:opacity-50 ${
+          error ? "ring-2 ring-error" : ""
         } ${className}`}
         {...props}
       />
-      {error ? <p className="text-xs text-red-500">{error}</p> : null}
+      {error ? <p className="text-xs text-error">{error}</p> : null}
     </div>
   );
 }


### PR DESCRIPTION
## ✏️ 작업 내용

피그마 시안 기준으로 공용 컴포넌트 스타일 업데이트

**Input**
- 테두리 제거 → 배경색 `bg-blue-200` (`#ECEFF4`)
- 에러 표시 방식: `border-red-500` → `ring-error`
- 에러 텍스트: `text-red-500` → `text-error` (`#FF6577`)
- 레이블: `text-gray-700` → `text-blue-900` (`#2D394E`)
- 플레이스홀더: `text-gray-400` → `text-blue-400` (`#ABB8CE`)
- 반경: `rounded-lg` → `rounded-xl` (12px)
- 높이: `h-11` (44px, 피그마 모바일 기준)

**Button**
- primary: `bg-black` → `bg-black-500` (`#454545`)
- disabled: `bg-gray-300` → `bg-blue-300` (`#CBD3E1`)
- 반경: `rounded-lg` → `rounded-xl` (12px)

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 공용 UI 컴포넌트 피그마 시안 반영 (Input, Button) 기능이 추가됩니다.

Closes #65