### PR TITLE
feat: EmotionLog 엔티티 Zod 스키마 정의 (T037)

### DIFF
--- a/src/entities/emotion-log/model/schema.ts
+++ b/src/entities/emotion-log/model/schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const emotionSchema = z.enum(["MOVED", "HAPPY", "WORRIED", "SAD", "ANGRY"]);
+
+export const emotionLogSchema = z.object({
+  id: z.number().int().positive(),
+  userId: z.number().int().positive(),
+  emotion: emotionSchema,
+  createdAt: z.string().datetime(),
+});
+
+export type Emotion = z.infer<typeof emotionSchema>;
+export type EmotionLog = z.infer<typeof emotionLogSchema>;


### PR DESCRIPTION
## ✏️ 작업 내용

- EmotionLog 엔티티 Zod 스키마 정의 (`src/entities/emotion-log/model/schema.ts`)
- `emotionSchema`: `MOVED | HAPPY | WORRIED | SAD | ANGRY` (swagger `_36_Enums.Emotion` 기준 영문)
- `emotionLogSchema`: id, userId, emotion, createdAt — id/userId는 `.int().positive()` 제약 적용
- TypeScript 타입 export: `Emotion`, `EmotionLog`

Closes #78

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 EmotionLog 엔티티 Zod 스키마 정의 (T037) 기능이 추가됩니다.

Closes #78