### PR TITLE
feat: useEpigrams 에피그램 목록 무한 스크롤 훅 구현 (T038)

### DIFF
--- a/src/entities/epigram/api/useEpigrams.ts
+++ b/src/entities/epigram/api/useEpigrams.ts
@@ -1,0 +1,27 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import { apiClient } from "@/shared/api/client";
+import type { EpigramListResponse } from "../model/schema";
+
+interface UseEpigramsParams {
+  limit: number;
+  keyword?: string;
+  writerId?: number;
+}
+
+export function useEpigrams({ limit, keyword, writerId }: UseEpigramsParams) {
+  return useInfiniteQuery({
+    queryKey: ["epigrams", { limit, keyword, writerId }],
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams({ limit: String(limit) });
+      if (pageParam !== undefined) params.set("cursor", String(pageParam));
+      if (keyword) params.set("keyword", keyword);
+      if (writerId !== undefined) params.set("writerId", String(writerId));
+
+      const response = await apiClient.get<EpigramListResponse>(`/api/epigrams?${params}`);
+      return response.data;
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- `useInfiniteQuery` 기반 cursor 페이지네이션 훅 구현
- 파라미터: `limit` (필수), `keyword` / `writerId` (선택)
- `getNextPageParam`: `nextCursor ?? undefined` 로 마지막 페이지 감지

Closes #80

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 useEpigrams 에피그램 목록 무한 스크롤 훅 구현 (T038) 기능이 추가됩니다.

Closes #80