### PR TITLE
feat: useTodayEpigram 오늘의 에피그램 조회 훅 구현 (T039)

### DIFF
--- a/src/entities/epigram/api/useTodayEpigram.ts
+++ b/src/entities/epigram/api/useTodayEpigram.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "@/shared/api/client";
+import type { EpigramDetail } from "../model/schema";
+
+export function useTodayEpigram() {
+  return useQuery({
+    queryKey: ["epigrams", "today"],
+    queryFn: async () => {
+      const response = await apiClient.get<EpigramDetail | null>("/api/epigrams/today");
+      return response.data;
+    },
+  });
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- `GET /api/epigrams/today` → `EpigramDetail | null` 조회 훅
- swagger 기준 nullable 응답 처리

Closes #82

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 useTodayEpigram 오늘의 에피그램 조회 훅 구현 (T039) 기능이 추가됩니다.

Closes #82