### PR TITLE
feat: Comment 엔티티 스키마 + useRecentComments 훅 구현 (T040)

### DIFF
--- a/src/entities/comment/api/useRecentComments.ts
+++ b/src/entities/comment/api/useRecentComments.ts
@@ -1,0 +1,23 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import { apiClient } from "@/shared/api/client";
+import type { CommentListResponse } from "../model/schema";
+
+interface UseRecentCommentsParams {
+  limit: number;
+}
+
+export function useRecentComments({ limit }: UseRecentCommentsParams) {
+  return useInfiniteQuery({
+    queryKey: ["comments", { limit }],
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams({ limit: String(limit) });
+      if (pageParam !== undefined) params.set("cursor", String(pageParam));
+
+      const response = await apiClient.get<CommentListResponse>(`/api/comments?${params}`);
+      return response.data;
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+}

--- a/src/entities/comment/model/schema.ts
+++ b/src/entities/comment/model/schema.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+import { buildPaginatedSchema } from "@/shared/types/pagination";
+
+export const writerSchema = z.object({
+  id: z.number().int().positive(),
+  nickname: z.string(),
+  image: z.string().nullable(),
+});
+
+export const commentSchema = z.object({
+  id: z.number().int().positive(),
+  epigramId: z.number().int().positive(),
+  writer: writerSchema,
+  isPrivate: z.boolean(),
+  content: z.string(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export const commentListResponseSchema = buildPaginatedSchema(commentSchema);
+
+export type Writer = z.infer<typeof writerSchema>;
+export type Comment = z.infer<typeof commentSchema>;
+export type CommentListResponse = z.infer<typeof commentListResponseSchema>;


### PR DESCRIPTION
## ✏️ 작업 내용

- `commentSchema`: swagger `CommentType` 기준 — writerSchema(id/nickname/image), isPrivate, content, timestamps
- `writerSchema` export로 타입/스키마 일관성 유지
- `useRecentComments`: `GET /api/comments` cursor 기반 무한 스크롤 훅

Closes #84

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 Comment 엔티티 스키마 + useRecentComments 훅 구현 (T040) 기능이 추가됩니다.

Closes #84