### PR TITLE
feat: useTodayEmotion 오늘의 감정 조회 훅 구현 (T041)

### DIFF
--- a/src/entities/emotion-log/api/useTodayEmotion.ts
+++ b/src/entities/emotion-log/api/useTodayEmotion.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "@/shared/api/client";
+import type { EmotionLog } from "../model/schema";
+
+export function useTodayEmotion() {
+  return useQuery({
+    queryKey: ["emotionLogs", "today"],
+    queryFn: async () => {
+      const response = await apiClient.get<EmotionLog | null>("/api/emotionLogs/today");
+      return response.data;
+    },
+  });
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- `GET /api/emotionLogs/today` → `EmotionLog | null` 조회 훅
- swagger 기준 nullable 응답 처리 (오늘 감정 미등록 시 null)

Closes #86

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 useTodayEmotion 오늘의 감정 조회 훅 구현 (T041) 기능이 추가됩니다.

Closes #86