### PR TITLE
feat: postTodayEmotion 오늘의 감정 등록 함수 구현 (T042)

### DIFF
--- a/src/entities/emotion-log/api/postTodayEmotion.ts
+++ b/src/entities/emotion-log/api/postTodayEmotion.ts
@@ -1,0 +1,7 @@
+import { apiClient } from "@/shared/api/client";
+import type { Emotion, EmotionLog } from "../model/schema";
+
+export async function postTodayEmotion(emotion: Emotion): Promise<EmotionLog> {
+  const response = await apiClient.post<EmotionLog>("/api/emotionLogs/today", { emotion });
+  return response.data;
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- `POST /api/emotionLogs/today` — 오늘의 감정 등록 순수 API 함수
- `Emotion` 타입 파라미터 → `EmotionLog` 반환
- 뮤테이션(useMutation) 호출용으로 설계

Closes #88

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 postTodayEmotion 오늘의 감정 등록 함수 구현 (T042) 기능이 추가됩니다.

Closes #88