### PR TITLE
fix: T032 로그인 페이지 피그마 시안 반영 (#91)

### DIFF
--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -35,22 +35,24 @@ export function LoginForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
-      <Input
-        label="이메일"
-        type="email"
-        placeholder="이메일을 입력해 주세요"
-        error={errors.email?.message}
-        {...register("email")}
-      />
-      <Input
-        label="비밀번호"
-        type="password"
-        placeholder="비밀번호를 입력해 주세요"
-        error={errors.password?.message}
-        {...register("password")}
-      />
-      <Button type="submit" isLoading={isSubmitting} className="w-full">
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5">
+      <div className="flex flex-col gap-[10px]">
+        <Input
+          type="email"
+          placeholder="이메일"
+          error={errors.email?.message}
+          aria-label="이메일"
+          {...register("email")}
+        />
+        <Input
+          type="password"
+          placeholder="비밀번호"
+          error={errors.password?.message}
+          aria-label="비밀번호"
+          {...register("password")}
+        />
+      </div>
+      <Button type="submit" isLoading={isSubmitting} className="h-11 w-full">
         로그인
       </Button>
     </form>

--- a/src/shared/ui/EpigramLogo.tsx
+++ b/src/shared/ui/EpigramLogo.tsx
@@ -1,0 +1,7 @@
+export function EpigramLogo() {
+  return (
+    <div className="flex items-center justify-center">
+      <span className="text-[26px] font-black leading-none text-black-950">Epigram</span>
+    </div>
+  );
+}

--- a/src/views/login/ui/LoginPage.tsx
+++ b/src/views/login/ui/LoginPage.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { LoginForm } from "@/features/auth/ui/LoginForm";
+import { EpigramLogo } from "@/shared/ui/EpigramLogo";
 
 export async function LoginPage() {
   const cookieStore = await cookies();
@@ -14,27 +15,84 @@ export async function LoginPage() {
 
   return (
     <div className="flex flex-1 flex-col items-center justify-center px-6 py-16">
-      <div className="w-full max-w-sm">
-        <h1 className="mb-8 text-center font-serif text-2xl font-bold text-black-950">로그인</h1>
-        <LoginForm />
-        <div className="my-6 flex items-center gap-4">
-          <hr className="flex-1 border-line-200" />
-          <span className="text-sm text-black-300">또는</span>
-          <hr className="flex-1 border-line-200" />
+      <div className="flex w-full max-w-sm flex-col gap-[50px]">
+        <EpigramLogo />
+        <div className="flex flex-col gap-[50px]">
+          <div className="flex flex-col gap-[10px]">
+            <LoginForm />
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-blue-400">회원이 아니신가요?</span>
+              <Link href="/signup" className="text-sm font-medium text-black-600 hover:underline">
+                가입하기
+              </Link>
+            </div>
+          </div>
+          <SocialLoginSection kakaoOauthUrl={kakaoOauthUrl} />
         </div>
-        <a
-          href={kakaoOauthUrl}
-          className="flex h-11 w-full items-center justify-center gap-2 rounded-xl bg-[#FEE500] text-sm font-semibold text-[#191919] transition-colors hover:bg-[#F0D800]"
-        >
-          카카오로 로그인
-        </a>
-        <p className="mt-6 text-center text-sm text-black-300">
-          계정이 없으신가요?{" "}
-          <Link href="/signup" className="font-semibold text-blue-700 hover:underline">
-            회원가입
-          </Link>
-        </p>
       </div>
     </div>
+  );
+}
+
+interface SocialLoginSectionProps {
+  kakaoOauthUrl: string;
+}
+
+function SocialLoginSection({ kakaoOauthUrl }: SocialLoginSectionProps) {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center gap-[14px]">
+        <hr className="flex-1 border-line-200" />
+        <span className="text-xs text-blue-400">SNS 계정으로 로그인하기</span>
+        <hr className="flex-1 border-line-200" />
+      </div>
+      <div className="flex justify-center gap-4">
+        <SocialIconButton
+          href="https://nid.naver.com/oauth2.0/authorize"
+          label="네이버로 로그인"
+          bgColor="#03C75A"
+        >
+          <span className="text-white font-bold text-sm leading-none">N</span>
+        </SocialIconButton>
+        <SocialIconButton
+          href="https://accounts.google.com/o/oauth2/v2/auth"
+          label="구글로 로그인"
+          bgColor="#ffffff"
+          className="border border-line-200"
+        >
+          <span className="text-[#4285F4] font-bold text-sm leading-none">G</span>
+        </SocialIconButton>
+        <SocialIconButton href={kakaoOauthUrl} label="카카오로 로그인" bgColor="#FEE500">
+          <span className="text-[#191919] font-bold text-sm leading-none">K</span>
+        </SocialIconButton>
+      </div>
+    </div>
+  );
+}
+
+interface SocialIconButtonProps {
+  href: string;
+  label: string;
+  bgColor: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+function SocialIconButton({
+  href,
+  label,
+  bgColor,
+  className = "",
+  children,
+}: SocialIconButtonProps) {
+  return (
+    <a
+      href={href}
+      aria-label={label}
+      className={`flex h-10 w-10 items-center justify-center rounded-full transition-opacity hover:opacity-80 ${className}`}
+      style={{ backgroundColor: bgColor }}
+    >
+      {children}
+    </a>
   );
 }


### PR DESCRIPTION
## ✏️ 작업 내용

- 상단 `<h1>로그인</h1>` → `EpigramLogo` 컴포넌트로 교체
- SNS 구분선 텍스트: "또는" → "SNS 계정으로 로그인하기"
- 소셜 로그인: 카카오 1개 → 네이버/구글/카카오 원형 아이콘 3개
- 가입 링크 텍스트/색상 수정: "계정이 없으신가요? 회원가입(파란색)" → "회원이 아니신가요? 가입하기(black-600)"
- 폼 컨테이너 gap 50px 적용, Input placeholder-only + aria-label, 버튼 h-11
- `src/shared/ui/EpigramLogo.tsx` 공유 컴포넌트 추가

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 T032 로그인 페이지 피그마 시안 반영 기능이 추가됩니다.

Closes #91