### PR TITLE
fix: T033 회원가입 페이지 피그마 시안 반영 (#92)

### DIFF
--- a/src/features/auth/ui/SignUpForm.tsx
+++ b/src/features/auth/ui/SignUpForm.tsx
@@ -38,36 +38,38 @@ export function SignUpForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
-      <Input
-        label="이메일"
-        type="email"
-        placeholder="이메일을 입력해 주세요"
-        error={errors.email?.message}
-        {...register("email")}
-      />
-      <Input
-        label="닉네임"
-        type="text"
-        placeholder="닉네임을 입력해 주세요"
-        error={errors.nickname?.message}
-        {...register("nickname")}
-      />
-      <Input
-        label="비밀번호"
-        type="password"
-        placeholder="비밀번호를 입력해 주세요"
-        error={errors.password?.message}
-        {...register("password")}
-      />
-      <Input
-        label="비밀번호 확인"
-        type="password"
-        placeholder="비밀번호를 다시 입력해 주세요"
-        error={errors.passwordConfirmation?.message}
-        {...register("passwordConfirmation")}
-      />
-      <Button type="submit" isLoading={isSubmitting} className="w-full">
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5">
+      <div className="flex flex-col gap-[10px]">
+        <Input
+          type="email"
+          placeholder="이메일"
+          error={errors.email?.message}
+          aria-label="이메일"
+          {...register("email")}
+        />
+        <Input
+          type="text"
+          placeholder="닉네임"
+          error={errors.nickname?.message}
+          aria-label="닉네임"
+          {...register("nickname")}
+        />
+        <Input
+          type="password"
+          placeholder="비밀번호"
+          error={errors.password?.message}
+          aria-label="비밀번호"
+          {...register("password")}
+        />
+        <Input
+          type="password"
+          placeholder="비밀번호 확인"
+          error={errors.passwordConfirmation?.message}
+          aria-label="비밀번호 확인"
+          {...register("passwordConfirmation")}
+        />
+      </div>
+      <Button type="submit" isLoading={isSubmitting} className="h-11 w-full">
         가입하기
       </Button>
     </form>

--- a/src/shared/ui/EpigramLogo.tsx
+++ b/src/shared/ui/EpigramLogo.tsx
@@ -1,0 +1,7 @@
+export function EpigramLogo() {
+  return (
+    <div className="flex items-center justify-center">
+      <span className="text-[26px] font-black leading-none text-black-950">Epigram</span>
+    </div>
+  );
+}

--- a/src/views/signup/ui/SignUpPage.tsx
+++ b/src/views/signup/ui/SignUpPage.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { SignUpForm } from "@/features/auth/ui/SignUpForm";
+import { EpigramLogo } from "@/shared/ui/EpigramLogo";
 
 export async function SignUpPage() {
   const cookieStore = await cookies();
@@ -12,15 +13,17 @@ export async function SignUpPage() {
 
   return (
     <div className="flex flex-1 flex-col items-center justify-center px-6 py-16">
-      <div className="w-full max-w-sm">
-        <h1 className="mb-8 text-center font-serif text-2xl font-bold text-black-950">회원가입</h1>
-        <SignUpForm />
-        <p className="mt-6 text-center text-sm text-black-300">
-          이미 계정이 있으신가요?{" "}
-          <Link href="/login" className="font-semibold text-blue-700 hover:underline">
-            로그인
-          </Link>
-        </p>
+      <div className="flex w-full max-w-sm flex-col gap-[50px]">
+        <EpigramLogo />
+        <div className="flex flex-col gap-[10px]">
+          <SignUpForm />
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-blue-400">이미 회원이신가요?</span>
+            <Link href="/login" className="text-sm font-medium text-black-600 hover:underline">
+              로그인
+            </Link>
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## ✏️ 작업 내용

- 상단 `<h1>회원가입</h1>` → `EpigramLogo` 컴포넌트로 교체
- 로그인 링크 텍스트/색상 수정: "이미 계정이 있으신가요? 로그인(파란색)" → "이미 회원이신가요? 로그인(black-600)"
- 폼 컨테이너 gap 50px 적용, Input placeholder-only + aria-label, 버튼 h-11

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 T033 회원가입 페이지 피그마 시안 반영 기능이 추가됩니다.

Closes #92