### PR TITLE
feat: Epigram, Comment, EmotionLog 엔티티 index.ts 퍼블릭 API 정의 (#98)

### DIFF
--- a/specs/001-epigram-core-pages/tasks.md
+++ b/specs/001-epigram-core-pages/tasks.md
@@ -98,17 +98,17 @@
 
 ### US2 — 엔티티 & 모델 (의존: Phase 2)
 
-- [ ] T036 [P] [US2] Epigram 엔티티 Zod 스키마 정의 — `isLiked`는 상세 조회(`GET /epigrams/{id}`) 응답에만 존재, 목록(`GET /epigrams`) 응답에는 없음 (`src/entities/epigram/model/schema.ts`)
-- [ ] T037 [P] [US2] EmotionLog 엔티티 Zod 스키마 정의 — Emotion enum: `MOVED | HAPPY | WORRIED | SAD | ANGRY` (영문, swagger 기준) (`src/entities/emotion-log/model/schema.ts`)
+- [x] T036 [P] [US2] Epigram 엔티티 Zod 스키마 정의 — `isLiked`는 상세 조회(`GET /epigrams/{id}`) 응답에만 존재, 목록(`GET /epigrams`) 응답에는 없음 (`src/entities/epigram/model/schema.ts`)
+- [x] T037 [P] [US2] EmotionLog 엔티티 Zod 스키마 정의 — Emotion enum: `MOVED | HAPPY | WORRIED | SAD | ANGRY` (영문, swagger 기준) (`src/entities/emotion-log/model/schema.ts`)
 
 ### US2 — API 레이어
 
-- [ ] T038 [P] [US2] 에피그램 목록 API 훅 — `useEpigrams` (cursor 기반 페이지네이션) (`src/entities/epigram/api/useEpigrams.ts`)
-- [ ] T039 [P] [US2] 오늘의 에피그램 API 훅 — `useTodayEpigram` (`src/entities/epigram/api/useTodayEpigram.ts`)
-- [ ] T040 [P] [US2] 최근 댓글 목록 API 훅 — `useRecentComments` (`src/entities/comment/api/useRecentComments.ts`)
-- [ ] T041 [P] [US2] 오늘의 감정 조회 API 훅 — `useTodayEmotion` (`src/entities/emotion-log/api/useTodayEmotion.ts`)
-- [ ] T042 [P] [US2] 오늘의 감정 등록 API 함수 — `postTodayEmotion` (`src/entities/emotion-log/api/postTodayEmotion.ts`)
-- [ ] T043 [US2] Epigram, Comment, EmotionLog 엔티티 index.ts 퍼블릭 API 정의 (`src/entities/epigram/index.ts`, `src/entities/comment/index.ts`, `src/entities/emotion-log/index.ts`)
+- [x] T038 [P] [US2] 에피그램 목록 API 훅 — `useEpigrams` (cursor 기반 페이지네이션) (`src/entities/epigram/api/useEpigrams.ts`)
+- [x] T039 [P] [US2] 오늘의 에피그램 API 훅 — `useTodayEpigram` (`src/entities/epigram/api/useTodayEpigram.ts`)
+- [x] T040 [P] [US2] 최근 댓글 목록 API 훅 — `useRecentComments` (`src/entities/comment/api/useRecentComments.ts`)
+- [x] T041 [P] [US2] 오늘의 감정 조회 API 훅 — `useTodayEmotion` (`src/entities/emotion-log/api/useTodayEmotion.ts`)
+- [x] T042 [P] [US2] 오늘의 감정 등록 API 함수 — `postTodayEmotion` (`src/entities/emotion-log/api/postTodayEmotion.ts`)
+- [x] T043 [US2] Epigram, Comment, EmotionLog 엔티티 index.ts 퍼블릭 API 정의 (`src/entities/epigram/index.ts`, `src/entities/comment/index.ts`, `src/entities/emotion-log/index.ts`)
 
 ### US2 — Features (의존: T036~T043)
 

--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -1,0 +1,4 @@
+export { writerSchema, commentSchema, commentListResponseSchema } from "./model/schema";
+export type { Writer, Comment, CommentListResponse } from "./model/schema";
+
+export { useRecentComments } from "./api/useRecentComments";

--- a/src/entities/emotion-log/index.ts
+++ b/src/entities/emotion-log/index.ts
@@ -1,0 +1,5 @@
+export { emotionSchema, emotionLogSchema } from "./model/schema";
+export type { Emotion, EmotionLog } from "./model/schema";
+
+export { useTodayEmotion } from "./api/useTodayEmotion";
+export { postTodayEmotion } from "./api/postTodayEmotion";

--- a/src/entities/epigram/index.ts
+++ b/src/entities/epigram/index.ts
@@ -1,0 +1,10 @@
+export {
+  epigramTagSchema,
+  epigramSchema,
+  epigramDetailSchema,
+  epigramListResponseSchema,
+} from "./model/schema";
+export type { EpigramTag, Epigram, EpigramDetail, EpigramListResponse } from "./model/schema";
+
+export { useEpigrams } from "./api/useEpigrams";
+export { useTodayEpigram } from "./api/useTodayEpigram";


### PR DESCRIPTION
## ✏️ 작업 내용

- `src/entities/epigram/index.ts` — 스키마, 타입, API 훅 퍼블릭 export
- `src/entities/comment/index.ts` — 스키마, 타입, API 훅 퍼블릭 export
- `src/entities/emotion-log/index.ts` — 스키마, 타입, API 함수 퍼블릭 export

FSD 아키텍처 원칙에 따라 각 엔티티의 내부 구현을 캡슐화하고 index.ts를 통해서만 외부에서 접근 가능하도록 한다.

Closes #98

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 Epigram, Comment, EmotionLog 엔티티 index.ts 퍼블릭 API 정의 기능이 추가됩니다.

Closes #98