### PR TITLE
feat: 에피그램 카드 위젯 구현 (#104)

### DIFF
--- a/specs/001-epigram-core-pages/tasks.md
+++ b/specs/001-epigram-core-pages/tasks.md
@@ -117,7 +117,7 @@
 ### US2 — Widgets (의존: T044)
 
 - [x] T045 [US2] 에피그램 피드 위젯 구현 — 오늘의 에피그램 + 에피그램 카드 + 더보기 버튼(5개씩) (`src/widgets/epigram-feed/ui/EpigramFeed.tsx`, `src/widgets/epigram-feed/index.ts`)
-- [ ] T046 [US2] 에피그램 카드 위젯 구현 — 내용, 저자, 태그 표시, 클릭 → 상세 이동 (`src/widgets/epigram-card/ui/EpigramCard.tsx`, `src/widgets/epigram-card/index.ts`)
+- [x] T046 [US2] 에피그램 카드 위젯 구현 — 내용, 저자, 태그 표시, 클릭 → 상세 이동 (`src/widgets/epigram-card/ui/EpigramCard.tsx`, `src/widgets/epigram-card/index.ts`)
 - [ ] T047 [US2] 최근 댓글 위젯 구현 — 댓글 목록, 더보기 버튼(4개씩), 댓글 작성자 클릭 → 유저 프로필 모달 (`src/widgets/comment-section/ui/RecentComments.tsx`)
 
 ### US2 — Pages & App Routes (의존: T045~T047)

--- a/src/widgets/epigram-card/index.ts
+++ b/src/widgets/epigram-card/index.ts
@@ -1,0 +1,1 @@
+export { EpigramCard } from "./ui/EpigramCard";

--- a/src/widgets/epigram-card/ui/EpigramCard.tsx
+++ b/src/widgets/epigram-card/ui/EpigramCard.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Link from "next/link";
+import React from "react";
+
+import type { Epigram } from "@/entities/epigram";
+
+interface EpigramCardProps {
+  epigram: Epigram;
+  /** 강조 표시 (오늘의 에피그램 등) */
+  isFeatured?: boolean;
+}
+
+function EpigramAttribution({
+  author,
+  referenceTitle,
+}: {
+  author: string;
+  referenceTitle: string | null;
+}): React.ReactElement {
+  const citation = referenceTitle ? `${author} 《${referenceTitle}》` : author;
+
+  return <footer className="mt-3 text-right text-sm text-black-300">— {citation}</footer>;
+}
+
+function EpigramTagList({ tags }: { tags: Epigram["tags"] }): React.ReactElement | null {
+  if (tags.length === 0) return null;
+
+  return (
+    <ul className="mt-4 flex flex-wrap gap-2" aria-label="태그 목록">
+      {tags.map((tag) => (
+        <li key={tag.id}>
+          <span className="rounded-full bg-blue-200 px-3 py-1 text-xs font-medium text-blue-700 transition-colors duration-150 hover:bg-blue-300">
+            #{tag.name}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function EpigramCard({ epigram, isFeatured = false }: EpigramCardProps): React.ReactElement {
+  const baseClasses =
+    "group block rounded-2xl border bg-white px-6 py-6 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2";
+
+  const featuredClasses = isFeatured
+    ? "border-blue-300 shadow-sm shadow-blue-100 hover:border-blue-400 hover:shadow-blue-200"
+    : "border-line-200 shadow-sm hover:border-blue-300";
+
+  return (
+    <Link href={`/epigrams/${epigram.id}`} className={`${baseClasses} ${featuredClasses}`}>
+      <article>
+        <blockquote>
+          <p
+            className={`font-serif leading-relaxed transition-colors duration-200 group-hover:text-black-900 ${
+              isFeatured ? "text-lg text-black-800" : "text-base text-black-700"
+            }`}
+          >
+            {epigram.content}
+          </p>
+          <EpigramAttribution author={epigram.author} referenceTitle={epigram.referenceTitle} />
+        </blockquote>
+        <EpigramTagList tags={epigram.tags} />
+      </article>
+    </Link>
+  );
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- `EpigramCard.tsx` — 재사용 가능한 에피그램 카드 위젯
- `index.ts` — 퍼블릭 API export

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 에피그램 카드 위젯 구현 기능이 추가됩니다.

Closes #104