### PR TITLE
chore: shared 기반 레이어 중간 리팩토링 (#110)

### DIFF
--- a/src/shared/api/QueryProvider.tsx
+++ b/src/shared/api/QueryProvider.tsx
@@ -1,14 +1,16 @@
 "use client";
 
+import type { ReactElement, ReactNode } from "react";
 import { useState } from "react";
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 interface QueryProviderProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
-export function QueryProvider({ children }: QueryProviderProps) {
+export function QueryProvider({ children }: QueryProviderProps): ReactElement {
   const [queryClient] = useState(
     () =>
       new QueryClient({

--- a/src/shared/hooks/useModal.ts
+++ b/src/shared/hooks/useModal.ts
@@ -1,4 +1,6 @@
-import React, { useCallback } from "react";
+import type { ReactNode } from "react";
+import { useCallback } from "react";
+
 import { useModalStore } from "@/shared/model/modalStore";
 
 let idCounter = 0;
@@ -9,7 +11,7 @@ function generateId(): string {
 }
 
 interface UseModalReturn {
-  open: (render: (onClose: () => void) => React.ReactNode) => string;
+  open: (render: (onClose: () => void) => ReactNode) => string;
   close: (id: string) => void;
   closeAll: () => void;
 }
@@ -18,7 +20,7 @@ export function useModal(): UseModalReturn {
   const { openModal, closeModal, closeAll } = useModalStore();
 
   const open = useCallback(
-    (render: (onClose: () => void) => React.ReactNode): string => {
+    (render: (onClose: () => void) => ReactNode): string => {
       const id = generateId();
       openModal({ id, render });
       return id;
@@ -26,12 +28,5 @@ export function useModal(): UseModalReturn {
     [openModal]
   );
 
-  const close = useCallback(
-    (id: string): void => {
-      closeModal(id);
-    },
-    [closeModal]
-  );
-
-  return { open, close, closeAll };
+  return { open, close: closeModal, closeAll };
 }

--- a/src/shared/lib/clipboard.ts
+++ b/src/shared/lib/clipboard.ts
@@ -4,7 +4,6 @@ export async function copyToClipboard(text: string): Promise<void> {
     return;
   }
 
-  // fallback for non-secure contexts
   const textarea = document.createElement("textarea");
   textarea.value = text;
   textarea.style.position = "fixed";

--- a/src/shared/model/modalStore.ts
+++ b/src/shared/model/modalStore.ts
@@ -1,8 +1,10 @@
+import type { ReactNode } from "react";
+
 import { create } from "zustand";
 
 interface ModalConfig {
   id: string;
-  render: (onClose: () => void) => React.ReactNode;
+  render: (onClose: () => void) => ReactNode;
 }
 
 interface ModalState {

--- a/src/shared/types/pagination.ts
+++ b/src/shared/types/pagination.ts
@@ -6,7 +6,13 @@ export interface PaginatedResponse<T> {
   list: T[];
 }
 
-export function buildPaginatedSchema<T extends z.ZodTypeAny>(itemSchema: T) {
+export function buildPaginatedSchema<T extends z.ZodTypeAny>(
+  itemSchema: T
+): z.ZodObject<{
+  totalCount: z.ZodNumber;
+  nextCursor: z.ZodNullable<z.ZodNumber>;
+  list: z.ZodArray<T>;
+}> {
   return z.object({
     totalCount: z.number(),
     nextCursor: z.number().nullable(),

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -1,4 +1,6 @@
-interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+import type { ButtonHTMLAttributes, ReactElement } from "react";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "ghost";
   isLoading?: boolean;
 }
@@ -19,7 +21,7 @@ export function Button({
   children,
   className = "",
   ...props
-}: ButtonProps) {
+}: ButtonProps): ReactElement {
   return (
     <button
       disabled={disabled || isLoading}

--- a/src/shared/ui/EpigramLogo.tsx
+++ b/src/shared/ui/EpigramLogo.tsx
@@ -1,4 +1,6 @@
-export function EpigramLogo() {
+import type { ReactElement } from "react";
+
+export function EpigramLogo(): ReactElement {
   return (
     <div className="flex items-center justify-center">
       <span className="text-[26px] font-black leading-none text-black-950">Epigram</span>

--- a/src/shared/ui/Input.tsx
+++ b/src/shared/ui/Input.tsx
@@ -1,9 +1,11 @@
-interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+import type { InputHTMLAttributes, ReactElement } from "react";
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   error?: string;
 }
 
-export function Input({ label, error, id, className = "", ...props }: InputProps) {
+export function Input({ label, error, id, className = "", ...props }: InputProps): ReactElement {
   const inputId = id ?? label;
 
   return (

--- a/src/shared/ui/Modal.tsx
+++ b/src/shared/ui/Modal.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import React, { useEffect, useRef } from "react";
+import type { MouseEvent, ReactElement, ReactNode } from "react";
+import { useEffect, useRef } from "react";
+
+import { Button } from "@/shared/ui/Button";
 
 interface ModalProps {
   onClose: () => void;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
-export function Modal({ onClose, children }: ModalProps): React.ReactElement {
+export function Modal({ onClose, children }: ModalProps): ReactElement {
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const mainContentRef = useRef<HTMLElement | null>(null);
 
@@ -27,7 +30,7 @@ export function Modal({ onClose, children }: ModalProps): React.ReactElement {
     };
   }, []);
 
-  function handleBackdropClick(e: React.MouseEvent<HTMLDivElement>): void {
+  function handleBackdropClick(e: MouseEvent<HTMLDivElement>): void {
     if (e.target === e.currentTarget) {
       onClose();
     }
@@ -61,7 +64,7 @@ export function ConfirmModal({
   cancelLabel = "취소",
   onConfirm,
   onClose,
-}: ConfirmModalProps): React.ReactElement {
+}: ConfirmModalProps): ReactElement {
   function handleConfirm(): void {
     onConfirm();
     onClose();
@@ -72,20 +75,12 @@ export function ConfirmModal({
       <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
       {description && <p className="mt-2 text-sm text-gray-600">{description}</p>}
       <div className="mt-6 flex justify-end gap-3">
-        <button
-          type="button"
-          onClick={onClose}
-          className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-        >
+        <Button variant="secondary" onClick={onClose}>
           {cancelLabel}
-        </button>
-        <button
-          type="button"
-          onClick={handleConfirm}
-          className="rounded-lg bg-black px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
-        >
+        </Button>
+        <Button variant="primary" onClick={handleConfirm}>
           {confirmLabel}
-        </button>
+        </Button>
       </div>
     </Modal>
   );

--- a/src/shared/ui/ModalProvider.tsx
+++ b/src/shared/ui/ModalProvider.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import React from "react";
+import type { ReactElement } from "react";
+import { Fragment } from "react";
+
 import { useModalStore } from "@/shared/model/modalStore";
 
-export function ModalProvider(): React.ReactElement | null {
+export function ModalProvider(): ReactElement | null {
   const { modals, closeModal } = useModalStore();
 
   if (modals.length === 0) return null;
@@ -11,7 +13,7 @@ export function ModalProvider(): React.ReactElement | null {
   return (
     <>
       {modals.map((modal) => (
-        <React.Fragment key={modal.id}>{modal.render(() => closeModal(modal.id))}</React.Fragment>
+        <Fragment key={modal.id}>{modal.render(() => closeModal(modal.id))}</Fragment>
       ))}
     </>
   );

--- a/src/shared/ui/Tag.tsx
+++ b/src/shared/ui/Tag.tsx
@@ -1,26 +1,24 @@
-import React from "react";
+import type { ReactElement } from "react";
 
 interface TagProps {
   label: string;
   onClick?: (label: string) => void;
 }
 
-export function Tag({ label, onClick }: TagProps): React.ReactElement {
+const TAG_CLASS = "rounded-full bg-blue-50 px-3 py-1 text-sm font-medium text-blue-600";
+
+export function Tag({ label, onClick }: TagProps): ReactElement {
   if (onClick) {
     return (
       <button
         type="button"
         onClick={() => onClick(label)}
-        className="rounded-full bg-blue-50 px-3 py-1 text-sm font-medium text-blue-600 hover:bg-blue-100 transition-colors"
+        className={`${TAG_CLASS} hover:bg-blue-100 transition-colors`}
       >
         #{label}
       </button>
     );
   }
 
-  return (
-    <span className="rounded-full bg-blue-50 px-3 py-1 text-sm font-medium text-blue-600">
-      #{label}
-    </span>
-  );
+  return <span className={TAG_CLASS}>#{label}</span>;
 }


### PR DESCRIPTION
## ✏️ 작업 내용

## 변경 사항

React 19 + Next.js 16 기준으로 shared 레이어 코드 품질 개선

### 주요 수정

- **React namespace 제거**: `React.ReactNode` → `ReactNode`, `React.ReactElement` → `ReactElement` (named import)
- **modalStore**: `React.ReactNode` 타입 사용에 필요한 `import type { ReactNode }` 추가
- **useModal**: `import React` → `import type { ReactNode }`, 불필요한 `close` 래퍼 제거 → `closeModal` 직접 노출
- **Modal**: raw `<button>` → `Button` 컴포넌트 사용 (ConfirmModal), React namespace 제거
- **ModalProvider**: `React.Fragment` → `Fragment`, React namespace 제거
- **Button / Input / Tag / EpigramLogo**: 반환 타입 명시 (`ReactElement`), React namespace → named import
- **Tag**: className 중복 상수(`TAG_CLASS`)로 추출
- **clipboard**: 자명한 주석 제거
- **pagination**: `buildPaginatedSchema` 반환 타입 명시

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 shared 기반 레이어 중간 리팩토링 기능이 추가됩니다.

Closes #110