### PR TITLE
chore: 인증(auth) 도메인 중간 리팩토링 (#112)

### DIFF
--- a/src/app/oauth/callback/kakao/page.tsx
+++ b/src/app/oauth/callback/kakao/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import type { ReactElement } from "react";
 import { Suspense, useEffect } from "react";
 
 import { useRouter, useSearchParams } from "next/navigation";
 
 import { signInKakao } from "@/entities/user";
 
-function KakaoCallbackHandler() {
+function KakaoCallbackHandler(): null {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -27,7 +28,7 @@ function KakaoCallbackHandler() {
   return null;
 }
 
-export default function KakaoCallbackPage() {
+export default function KakaoCallbackPage(): ReactElement {
   return (
     <div className="flex flex-1 items-center justify-center">
       <p className="text-sm text-black-300">카카오 로그인 처리 중...</p>

--- a/src/entities/user/api/auth.ts
+++ b/src/entities/user/api/auth.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@/shared/api/client";
+
 import type { SignUpResponse, SignInResponse } from "../model/types";
 
 export interface SignUpBody {

--- a/src/entities/user/api/kakao.ts
+++ b/src/entities/user/api/kakao.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@/shared/api/client";
+
 import type { SignInResponse } from "../model/types";
 
 export interface SignInKakaoBody {

--- a/src/entities/user/api/user.ts
+++ b/src/entities/user/api/user.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@/shared/api/client";
+
 import { userSchema, type User } from "../model/schema";
 
 export async function getMe(): Promise<User> {

--- a/src/features/auth/api/logout.ts
+++ b/src/features/auth/api/logout.ts
@@ -4,7 +4,11 @@ import { useRouter } from "next/navigation";
 
 import { logout } from "@/entities/user";
 
-export function useLogout() {
+interface UseLogoutReturn {
+  handleLogout: () => Promise<void>;
+}
+
+export function useLogout(): UseLogoutReturn {
   const router = useRouter();
 
   async function handleLogout(): Promise<void> {

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,0 +1,4 @@
+export { AuthLeftPanel } from "./ui/AuthLeftPanel";
+export { LoginForm } from "./ui/LoginForm";
+export { SignUpForm } from "./ui/SignUpForm";
+export { useLogout } from "./api/logout";

--- a/src/features/auth/ui/AuthLeftPanel.tsx
+++ b/src/features/auth/ui/AuthLeftPanel.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement } from "react";
+
+export function AuthLeftPanel(): ReactElement {
+  return (
+    <div className="hidden tablet:flex tablet:w-[380px] desktop:w-[460px] flex-col justify-between bg-blue-950 p-12">
+      <span className="font-serif text-xl font-black tracking-tight text-white">Epigram</span>
+
+      <div className="flex flex-col gap-5">
+        <span
+          className="font-serif leading-none text-blue-400"
+          style={{ fontSize: "80px" }}
+          aria-hidden="true"
+        >
+          {"\u201C"}
+        </span>
+        <p className="font-serif text-xl leading-relaxed text-blue-100">
+          나만 갖고 있기엔
+          <br />
+          아까운 글이 있지 않나요?
+        </p>
+        <p className="font-serif text-sm text-blue-500">— Epigram</p>
+      </div>
+
+      <p className="text-xs tracking-wide text-blue-600">다른 사람들과 감정을 공유해 보세요</p>
+    </div>
+  );
+}

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { ReactElement } from "react";
+
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
@@ -10,7 +12,7 @@ import { Input } from "@/shared/ui/Input";
 
 import { loginSchema, type LoginFormValues } from "../model/loginSchema";
 
-export function LoginForm() {
+export function LoginForm(): ReactElement {
   const router = useRouter();
 
   const {

--- a/src/features/auth/ui/SignUpForm.tsx
+++ b/src/features/auth/ui/SignUpForm.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { ReactElement } from "react";
+
 import { zodResolver } from "@hookform/resolvers/zod";
 import { isAxiosError } from "axios";
 import { useRouter } from "next/navigation";
@@ -11,7 +13,7 @@ import { Input } from "@/shared/ui/Input";
 
 import { signUpSchema, type SignUpFormValues } from "../model/signUpSchema";
 
-export function SignUpForm() {
+export function SignUpForm(): ReactElement {
   const router = useRouter();
 
   const {

--- a/src/views/login/ui/LoginPage.tsx
+++ b/src/views/login/ui/LoginPage.tsx
@@ -1,11 +1,14 @@
+import type { ReactElement, ReactNode } from "react";
+
 import { cookies } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import { AuthLeftPanel } from "@/features/auth/ui/AuthLeftPanel";
 import { LoginForm } from "@/features/auth/ui/LoginForm";
 import { EpigramLogo } from "@/shared/ui/EpigramLogo";
 
-export async function LoginPage() {
+export async function LoginPage(): Promise<ReactElement> {
   const cookieStore = await cookies();
   if (cookieStore.has("accessToken")) {
     redirect("/epigrams");
@@ -40,37 +43,11 @@ export async function LoginPage() {
   );
 }
 
-function AuthLeftPanel() {
-  return (
-    <div className="hidden tablet:flex tablet:w-[380px] desktop:w-[460px] flex-col justify-between bg-blue-950 p-12">
-      <span className="font-serif text-xl font-black text-white tracking-tight">Epigram</span>
-
-      <div className="flex flex-col gap-5">
-        <span
-          className="font-serif leading-none text-blue-400"
-          style={{ fontSize: "80px" }}
-          aria-hidden="true"
-        >
-          {"\u201C"}
-        </span>
-        <p className="font-serif text-xl leading-relaxed text-blue-100">
-          나만 갖고 있기엔
-          <br />
-          아까운 글이 있지 않나요?
-        </p>
-        <p className="font-serif text-sm text-blue-500">— Epigram</p>
-      </div>
-
-      <p className="text-xs tracking-wide text-blue-600">다른 사람들과 감정을 공유해 보세요</p>
-    </div>
-  );
-}
-
 interface SocialLoginSectionProps {
   kakaoOauthUrl: string;
 }
 
-function SocialLoginSection({ kakaoOauthUrl }: SocialLoginSectionProps) {
+function SocialLoginSection({ kakaoOauthUrl }: SocialLoginSectionProps): ReactElement {
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-center gap-[14px]">
@@ -107,7 +84,7 @@ interface SocialIconButtonProps {
   label: string;
   bgColor: string;
   className?: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 function SocialIconButton({
@@ -116,7 +93,7 @@ function SocialIconButton({
   bgColor,
   className = "",
   children,
-}: SocialIconButtonProps) {
+}: SocialIconButtonProps): ReactElement {
   return (
     <a
       href={href}

--- a/src/views/signup/ui/SignUpPage.tsx
+++ b/src/views/signup/ui/SignUpPage.tsx
@@ -1,11 +1,14 @@
+import type { ReactElement } from "react";
+
 import { cookies } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import { AuthLeftPanel } from "@/features/auth/ui/AuthLeftPanel";
 import { SignUpForm } from "@/features/auth/ui/SignUpForm";
 import { EpigramLogo } from "@/shared/ui/EpigramLogo";
 
-export async function SignUpPage() {
+export async function SignUpPage(): Promise<ReactElement> {
   const cookieStore = await cookies();
   if (cookieStore.has("accessToken")) {
     redirect("/epigrams");
@@ -31,32 +34,6 @@ export async function SignUpPage() {
           </div>
         </div>
       </div>
-    </div>
-  );
-}
-
-function AuthLeftPanel() {
-  return (
-    <div className="hidden tablet:flex tablet:w-[380px] desktop:w-[460px] flex-col justify-between bg-blue-950 p-12">
-      <span className="font-serif text-xl font-black tracking-tight text-white">Epigram</span>
-
-      <div className="flex flex-col gap-5">
-        <span
-          className="font-serif leading-none text-blue-400"
-          style={{ fontSize: "80px" }}
-          aria-hidden="true"
-        >
-          {"\u201C"}
-        </span>
-        <p className="font-serif text-xl leading-relaxed text-blue-100">
-          나만 갖고 있기엔
-          <br />
-          아까운 글이 있지 않나요?
-        </p>
-        <p className="font-serif text-sm text-blue-500">— Epigram</p>
-      </div>
-
-      <p className="text-xs tracking-wide text-blue-600">다른 사람들과 감정을 공유해 보세요</p>
     </div>
   );
 }


### PR DESCRIPTION
## ✏️ 작업 내용

## 변경 사항

인증 도메인 코드 품질 개선 (React 19 기준)

### 주요 수정

- **entities/user/api**: import 그룹 간 빈 줄 추가 (lint `import/order`)
- **useLogout**: 반환 타입 명시 (`UseLogoutReturn` 인터페이스)
- **LoginForm / SignUpForm**: `ReactElement` 반환 타입 추가, React named import
- **AuthLeftPanel 추출**: `LoginPage`/`SignUpPage`에 중복된 컴포넌트를 `features/auth/ui/AuthLeftPanel.tsx`로 분리
- **LoginPage**: 공유 `AuthLeftPanel` 사용, `React.ReactNode` → `ReactNode`, 반환 타입 명시
- **SignUpPage**: 공유 `AuthLeftPanel` 사용, 반환 타입 명시
- **KakaoCallbackPage**: 반환 타입 명시, import 순서 정리
- **features/auth/index.ts**: `AuthLeftPanel` 배럴 export 추가

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 인증(auth) 도메인 중간 리팩토링 기능이 추가됩니다.

Closes #112