### PR TITLE
chore: 에피그램(epigram) 도메인 중간 리팩토링 (#114)

### DIFF
--- a/src/entities/epigram/api/useEpigrams.ts
+++ b/src/entities/epigram/api/useEpigrams.ts
@@ -1,6 +1,11 @@
-import { useInfiniteQuery } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  type UseInfiniteQueryResult,
+  type InfiniteData,
+} from "@tanstack/react-query";
 
 import { apiClient } from "@/shared/api/client";
+
 import type { EpigramListResponse } from "../model/schema";
 
 interface UseEpigramsParams {
@@ -9,7 +14,14 @@ interface UseEpigramsParams {
   writerId?: number;
 }
 
-export function useEpigrams({ limit, keyword, writerId }: UseEpigramsParams) {
+export function useEpigrams({
+  limit,
+  keyword,
+  writerId,
+}: UseEpigramsParams): UseInfiniteQueryResult<
+  InfiniteData<EpigramListResponse, number | undefined>,
+  Error
+> {
   return useInfiniteQuery({
     queryKey: ["epigrams", { limit, keyword, writerId }],
     queryFn: async ({ pageParam }) => {

--- a/src/entities/epigram/api/useTodayEpigram.ts
+++ b/src/entities/epigram/api/useTodayEpigram.ts
@@ -1,9 +1,10 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 
 import { apiClient } from "@/shared/api/client";
+
 import type { EpigramDetail } from "../model/schema";
 
-export function useTodayEpigram() {
+export function useTodayEpigram(): UseQueryResult<EpigramDetail | null, Error> {
   return useQuery({
     queryKey: ["epigrams", "today"],
     queryFn: async () => {


### PR DESCRIPTION
## ✏️ 작업 내용

## 변경 사항

에피그램 도메인 코드 품질 개선 (React 19 기준)

### 주요 수정

- **useEpigrams**: import 그룹 순서 정리, 반환 타입 명시 (`UseInfiniteQueryResult<InfiniteData<EpigramListResponse>>`)
- **useTodayEpigram**: import 그룹 순서 정리, 반환 타입 명시 (`UseQueryResult<EpigramDetail | null>`)

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 에피그램(epigram) 도메인 중간 리팩토링 기능이 추가됩니다.

Closes #114