### PR TITLE
chore: 댓글(comment) 도메인 중간 리팩토링 (#116)

### DIFF
--- a/src/entities/comment/api/useRecentComments.ts
+++ b/src/entities/comment/api/useRecentComments.ts
@@ -1,13 +1,23 @@
-import { useInfiniteQuery } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  type UseInfiniteQueryResult,
+  type InfiniteData,
+} from "@tanstack/react-query";
 
 import { apiClient } from "@/shared/api/client";
+
 import type { CommentListResponse } from "../model/schema";
 
 interface UseRecentCommentsParams {
   limit: number;
 }
 
-export function useRecentComments({ limit }: UseRecentCommentsParams) {
+export function useRecentComments({
+  limit,
+}: UseRecentCommentsParams): UseInfiniteQueryResult<
+  InfiniteData<CommentListResponse, number | undefined>,
+  Error
+> {
   return useInfiniteQuery({
     queryKey: ["comments", { limit }],
     queryFn: async ({ pageParam }) => {

--- a/src/widgets/comment-section/ui/RecentComments.tsx
+++ b/src/widgets/comment-section/ui/RecentComments.tsx
@@ -1,19 +1,26 @@
 "use client";
 
+import type { ReactElement } from "react";
+import { useState } from "react";
+
 import { ChevronDown, User } from "lucide-react";
 import Image from "next/image";
-import React, { useState } from "react";
 
 import type { Comment, Writer } from "@/entities/comment";
 import { useRecentComments } from "@/entities/comment";
 import { formatRelativeTime } from "@/shared/lib/date";
+import { Button } from "@/shared/ui/Button";
 import { Modal } from "@/shared/ui/Modal";
 
 const COMMENTS_PAGE_SIZE = 4;
 
 const SKELETON_ITEMS = Array.from({ length: COMMENTS_PAGE_SIZE });
 
-function WriterAvatar({ writer }: { writer: Writer }): React.ReactElement {
+interface WriterAvatarProps {
+  writer: Writer;
+}
+
+function WriterAvatar({ writer }: WriterAvatarProps): ReactElement {
   if (writer.image) {
     return (
       <Image
@@ -33,13 +40,12 @@ function WriterAvatar({ writer }: { writer: Writer }): React.ReactElement {
   );
 }
 
-function WriterProfileModal({
-  writer,
-  onClose,
-}: {
+interface WriterProfileModalProps {
   writer: Writer;
   onClose: () => void;
-}): React.ReactElement {
+}
+
+function WriterProfileModal({ writer, onClose }: WriterProfileModalProps): ReactElement {
   return (
     <Modal onClose={onClose}>
       <div className="flex flex-col items-center gap-4 py-2">
@@ -48,19 +54,19 @@ function WriterProfileModal({
           <p className="text-lg font-semibold text-black-800">{writer.nickname}</p>
           <p className="mt-1 text-sm text-black-300">ID: {writer.id}</p>
         </div>
-        <button
-          type="button"
-          onClick={onClose}
-          className="mt-2 rounded-xl bg-blue-200 px-6 py-2 text-sm font-medium text-blue-800 transition-colors hover:bg-blue-300 active:scale-95"
-        >
+        <Button variant="secondary" onClick={onClose} className="mt-2">
           닫기
-        </button>
+        </Button>
       </div>
     </Modal>
   );
 }
 
-function CommentItem({ comment }: { comment: Comment }): React.ReactElement {
+interface CommentItemProps {
+  comment: Comment;
+}
+
+function CommentItem({ comment }: CommentItemProps): ReactElement {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
@@ -93,13 +99,12 @@ function CommentItem({ comment }: { comment: Comment }): React.ReactElement {
   );
 }
 
-function LoadMoreButton({
-  isFetchingNextPage,
-  onClick,
-}: {
+interface LoadMoreButtonProps {
   isFetchingNextPage: boolean;
   onClick: () => void;
-}): React.ReactElement {
+}
+
+function LoadMoreButton({ isFetchingNextPage, onClick }: LoadMoreButtonProps): ReactElement {
   return (
     <button
       type="button"
@@ -120,7 +125,7 @@ function LoadMoreButton({
   );
 }
 
-export function RecentComments(): React.ReactElement {
+export function RecentComments(): ReactElement {
   const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useRecentComments({
     limit: COMMENTS_PAGE_SIZE,
   });


### PR DESCRIPTION
## ✏️ 작업 내용

## 변경 사항

댓글 도메인 코드 품질 개선 (React 19 기준)

### 주요 수정

- **useRecentComments**: import 그룹 순서 정리, 반환 타입 명시 (`UseInfiniteQueryResult`)
- **RecentComments**: `React` namespace 제거 → `ReactElement` named import
- **RecentComments**: 인라인 props 타입 → 명시적 `interface` 선언 (`WriterAvatarProps`, `WriterProfileModalProps`, `CommentItemProps`, `LoadMoreButtonProps`)
- **RecentComments**: import 순서 정리 (`react` → `lucide` → `next` → internal)
- **WriterProfileModal**: 닫기 raw `<button>` → `Button` 컴포넌트 사용

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 댓글(comment) 도메인 중간 리팩토링 기능이 추가됩니다.

Closes #116