### PR TITLE
chore: 감정(emotion) 도메인 중간 리팩토링 (#118)

### DIFF
--- a/src/entities/emotion-log/api/postTodayEmotion.ts
+++ b/src/entities/emotion-log/api/postTodayEmotion.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@/shared/api/client";
+
 import type { Emotion, EmotionLog } from "../model/schema";
 
 export async function postTodayEmotion(emotion: Emotion): Promise<EmotionLog> {

--- a/src/entities/emotion-log/api/useTodayEmotion.ts
+++ b/src/entities/emotion-log/api/useTodayEmotion.ts
@@ -1,9 +1,10 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 
 import { apiClient } from "@/shared/api/client";
+
 import type { EmotionLog } from "../model/schema";
 
-export function useTodayEmotion() {
+export function useTodayEmotion(): UseQueryResult<EmotionLog | null, Error> {
   return useQuery({
     queryKey: ["emotionLogs", "today"],
     queryFn: async () => {

--- a/src/features/emotion-select/model/useEmotionSelect.ts
+++ b/src/features/emotion-select/model/useEmotionSelect.ts
@@ -1,13 +1,15 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-import { postTodayEmotion, useTodayEmotion } from "@/entities/emotion-log";
 import type { Emotion } from "@/entities/emotion-log";
+import { postTodayEmotion, useTodayEmotion } from "@/entities/emotion-log";
 
-export function useEmotionSelect(): {
+interface UseEmotionSelectReturn {
   hasSelectedToday: boolean;
   isSubmitting: boolean;
   selectEmotion: (emotion: Emotion) => void;
-} {
+}
+
+export function useEmotionSelect(): UseEmotionSelectReturn {
   const queryClient = useQueryClient();
   const { data: todayEmotion } = useTodayEmotion();
 
@@ -19,7 +21,7 @@ export function useEmotionSelect(): {
   });
 
   return {
-    hasSelectedToday: todayEmotion !== null && todayEmotion !== undefined,
+    hasSelectedToday: todayEmotion != null,
     isSubmitting: isPending,
     selectEmotion: mutate,
   };

--- a/src/features/emotion-select/ui/EmotionSelector.tsx
+++ b/src/features/emotion-select/ui/EmotionSelector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import type { ReactElement } from "react";
 
 import type { Emotion } from "@/entities/emotion-log";
 
@@ -58,7 +58,7 @@ const EMOTION_OPTIONS: EmotionOption[] = [
   },
 ];
 
-export function EmotionSelector(): React.ReactElement | null {
+export function EmotionSelector(): ReactElement | null {
   const { hasSelectedToday, isSubmitting, selectEmotion } = useEmotionSelect();
 
   if (hasSelectedToday) return null;


### PR DESCRIPTION
## ✏️ 작업 내용

## 변경 사항

감정 도메인 코드 품질 개선 (React 19 기준)

### 주요 수정

- **postTodayEmotion**: import 그룹 순서 정리
- **useTodayEmotion**: import 순서 정리, 반환 타입 명시 (`UseQueryResult<EmotionLog | null>`)
- **useEmotionSelect**: 인라인 반환 타입 → `UseEmotionSelectReturn` 인터페이스, import 순서 정리, `hasSelectedToday` 조건 단순화 (`!== null && !== undefined` → `!= null`)
- **EmotionSelector**: `React` namespace 제거 → `ReactElement` named import

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 감정(emotion) 도메인 중간 리팩토링 기능이 추가됩니다.

Closes #118