### PR TITLE
chore: 위젯 & 헤더 중간 리팩토링 (#120)

### DIFF
--- a/src/widgets/epigram-card/ui/EpigramCard.tsx
+++ b/src/widgets/epigram-card/ui/EpigramCard.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import type { ReactElement } from "react";
+
 import Link from "next/link";
-import React from "react";
 
 import type { Epigram } from "@/entities/epigram";
 
@@ -11,19 +12,22 @@ interface EpigramCardProps {
   isFeatured?: boolean;
 }
 
-function EpigramAttribution({
-  author,
-  referenceTitle,
-}: {
+interface EpigramAttributionProps {
   author: string;
   referenceTitle: string | null;
-}): React.ReactElement {
+}
+
+function EpigramAttribution({ author, referenceTitle }: EpigramAttributionProps): ReactElement {
   const citation = referenceTitle ? `${author} 《${referenceTitle}》` : author;
 
   return <footer className="mt-3 text-right text-sm text-black-300">— {citation}</footer>;
 }
 
-function EpigramTagList({ tags }: { tags: Epigram["tags"] }): React.ReactElement | null {
+interface EpigramTagListProps {
+  tags: Epigram["tags"];
+}
+
+function EpigramTagList({ tags }: EpigramTagListProps): ReactElement | null {
   if (tags.length === 0) return null;
 
   return (
@@ -39,7 +43,7 @@ function EpigramTagList({ tags }: { tags: Epigram["tags"] }): React.ReactElement
   );
 }
 
-export function EpigramCard({ epigram, isFeatured = false }: EpigramCardProps): React.ReactElement {
+export function EpigramCard({ epigram, isFeatured = false }: EpigramCardProps): ReactElement {
   const baseClasses =
     "group block rounded-2xl border bg-white px-6 py-6 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2";
 

--- a/src/widgets/epigram-feed/ui/EpigramFeed.tsx
+++ b/src/widgets/epigram-feed/ui/EpigramFeed.tsx
@@ -1,15 +1,20 @@
 "use client";
 
-import { ChevronDown, BookOpenText } from "lucide-react";
-import Link from "next/link";
-import React from "react";
+import type { ReactElement } from "react";
 
-import { useTodayEpigram, useEpigrams } from "@/entities/epigram";
+import { BookOpenText, ChevronDown } from "lucide-react";
+import Link from "next/link";
+
 import type { Epigram } from "@/entities/epigram";
+import { useEpigrams, useTodayEpigram } from "@/entities/epigram";
 
 const FEED_PAGE_SIZE = 5;
 
-function EpigramTagList({ tags }: { tags: Epigram["tags"] }): React.ReactElement {
+interface EpigramTagListProps {
+  tags: Epigram["tags"];
+}
+
+function EpigramTagList({ tags }: EpigramTagListProps): ReactElement {
   return (
     <ul className="mt-3 flex flex-wrap gap-2" aria-label="태그 목록">
       {tags.map((tag) => (
@@ -23,7 +28,11 @@ function EpigramTagList({ tags }: { tags: Epigram["tags"] }): React.ReactElement
   );
 }
 
-function EpigramCard({ epigram }: { epigram: Epigram }): React.ReactElement {
+interface FeedEpigramCardProps {
+  epigram: Epigram;
+}
+
+function FeedEpigramCard({ epigram }: FeedEpigramCardProps): ReactElement {
   return (
     <Link
       href={`/epigrams/${epigram.id}`}
@@ -43,7 +52,7 @@ function EpigramCard({ epigram }: { epigram: Epigram }): React.ReactElement {
   );
 }
 
-function TodayEpigramSection(): React.ReactElement {
+function TodayEpigramSection(): ReactElement {
   const { data: todayEpigram, isLoading } = useTodayEpigram();
 
   if (isLoading) {
@@ -70,12 +79,12 @@ function TodayEpigramSection(): React.ReactElement {
   return (
     <section aria-label="오늘의 에피그램">
       <h2 className="mb-4 text-xl font-bold text-black-900">오늘의 에피그램</h2>
-      <EpigramCard epigram={todayEpigram} />
+      <FeedEpigramCard epigram={todayEpigram} />
     </section>
   );
 }
 
-function EpigramFeedList(): React.ReactElement {
+function EpigramFeedList(): ReactElement {
   const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useEpigrams({
     limit: FEED_PAGE_SIZE,
   });
@@ -104,7 +113,7 @@ function EpigramFeedList(): React.ReactElement {
   return (
     <div className="flex flex-col gap-4">
       {epigrams.map((epigram) => (
-        <EpigramCard key={epigram.id} epigram={epigram} />
+        <FeedEpigramCard key={epigram.id} epigram={epigram} />
       ))}
       {hasNextPage && (
         <button
@@ -128,7 +137,7 @@ function EpigramFeedList(): React.ReactElement {
   );
 }
 
-export function EpigramFeed(): React.ReactElement {
+export function EpigramFeed(): ReactElement {
   return (
     <div className="flex flex-col gap-10">
       <TodayEpigramSection />

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -1,7 +1,13 @@
-import Link from "next/link";
-import { Menu, User } from "lucide-react";
+import type { ReactElement } from "react";
 
-function Logo({ size }: { size: "sm" | "lg" }) {
+import { Menu, User } from "lucide-react";
+import Link from "next/link";
+
+interface LogoProps {
+  size: "sm" | "lg";
+}
+
+function Logo({ size }: LogoProps): ReactElement {
   const isLg = size === "lg";
   return (
     <Link href="/" className="flex items-center gap-1" aria-label="홈으로 이동">
@@ -19,7 +25,7 @@ interface UserSectionProps {
   textSize: "sm" | "md";
 }
 
-function UserSection({ iconSize, textSize }: UserSectionProps) {
+function UserSection({ iconSize, textSize }: UserSectionProps): ReactElement {
   const isLgIcon = iconSize === "lg";
   const isMdText = textSize === "md";
   return (
@@ -34,7 +40,7 @@ function UserSection({ iconSize, textSize }: UserSectionProps) {
   );
 }
 
-export function Header() {
+export function Header(): ReactElement {
   return (
     <header className="sticky top-0 z-50 w-full border-b border-line-100 bg-white">
       {/* Mobile (base ~ 743px): 햄버거 + 로고 / 유저 */}


### PR DESCRIPTION
## ✏️ 작업 내용

## 변경 사항

위젯 & 헤더 코드 품질 개선 (React 19 기준)

### 주요 수정

- **EpigramCard**: `React` namespace 제거 → `ReactElement` named import, import 순서 정리, 인라인 props → `EpigramAttributionProps` / `EpigramTagListProps` 인터페이스
- **EpigramFeed**: `React` namespace 제거, import 순서 정리, 내부 `EpigramCard` → `FeedEpigramCard`로 이름 명확화, 인라인 props → `FeedEpigramCardProps` / `EpigramTagListProps` 인터페이스
- **Header**: `React` namespace 제거, import 순서 정리 (lucide → next), `Logo` / `UserSection` 인라인 props → `LogoProps` / `UserSectionProps` 인터페이스, 반환 타입 명시

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 위젯 & 헤더 중간 리팩토링 기능이 추가됩니다.

Closes #120