### PR TITLE
chore: 페이지(views & app) 중간 리팩토링 (#122)

### DIFF
--- a/src/app/epigrams/page.tsx
+++ b/src/app/epigrams/page.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import type { ReactElement } from "react";
 
 import { EpigramsPage } from "@/views/epigrams";
 
-export default function Page(): React.ReactElement {
+export default function Page(): ReactElement {
   return <EpigramsPage />;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,14 @@
 import type { Metadata } from "next";
-import localFont from "next/font/local";
+import type { ReactNode } from "react";
+
 import { Nanum_Myeongjo } from "next/font/google";
+import localFont from "next/font/local";
+
 import { QueryProvider } from "@/shared/api/QueryProvider";
-import { Header } from "@/widgets/header";
-import "./globals.css";
 import { ModalProvider } from "@/shared/ui/ModalProvider";
+import { Header } from "@/widgets/header";
+
+import "./globals.css";
 
 const pretendard = localFont({
   src: "../../node_modules/pretendard/dist/web/variable/woff2/PretendardVariable.woff2",
@@ -26,11 +30,7 @@ export const metadata: Metadata = {
   description: "짧은 글귀를 공유하는 커뮤니티",
 };
 
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+export default function RootLayout({ children }: Readonly<{ children: ReactNode }>): ReactNode {
   return (
     <html
       lang="ko"

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,7 @@
+import type { ReactElement } from "react";
+
 import { LoginPage } from "@/views/login";
 
-export default function Page() {
-  return <LoginPage />;
+export default function Page(): Promise<ReactElement> {
+  return LoginPage();
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
+import type { ReactElement } from "react";
+
 import { LandingPage } from "@/views/landing";
 
-export default function Home() {
+export default function Home(): ReactElement {
   return <LandingPage />;
 }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,5 +1,7 @@
+import type { ReactElement } from "react";
+
 import { SignUpPage } from "@/views/signup";
 
-export default function Page() {
-  return <SignUpPage />;
+export default function Page(): Promise<ReactElement> {
+  return SignUpPage();
 }

--- a/src/views/epigrams/ui/EpigramsPage.tsx
+++ b/src/views/epigrams/ui/EpigramsPage.tsx
@@ -1,15 +1,16 @@
 "use client";
 
+import type { ReactElement } from "react";
+
 import { ArrowUp, Plus } from "lucide-react";
 import Link from "next/link";
-import React from "react";
 
 import { EmotionSelector } from "@/features/emotion-select";
 import { useScrollToTop } from "@/shared/hooks/useScrollToTop";
 import { RecentComments } from "@/widgets/comment-section";
 import { EpigramFeed } from "@/widgets/epigram-feed";
 
-function ScrollToTopButton(): React.ReactElement | null {
+function ScrollToTopButton(): ReactElement | null {
   const { isVisible, scrollToTop } = useScrollToTop();
 
   if (!isVisible) return null;
@@ -26,7 +27,7 @@ function ScrollToTopButton(): React.ReactElement | null {
   );
 }
 
-function CreateEpigramFab(): React.ReactElement {
+function CreateEpigramFab(): ReactElement {
   return (
     <Link
       href="/addepigram"
@@ -42,7 +43,7 @@ function CreateEpigramFab(): React.ReactElement {
   );
 }
 
-export function EpigramsPage(): React.ReactElement {
+export function EpigramsPage(): ReactElement {
   return (
     <main
       id="main-content"

--- a/src/views/landing/ui/LandingPage.tsx
+++ b/src/views/landing/ui/LandingPage.tsx
@@ -1,7 +1,9 @@
-import Link from "next/link";
-import { ChevronDown } from "lucide-react";
+import type { ReactElement } from "react";
 
-export function LandingPage() {
+import { ChevronDown } from "lucide-react";
+import Link from "next/link";
+
+export function LandingPage(): ReactElement {
   return (
     <div className="flex flex-col">
       <HeroSection />
@@ -12,7 +14,7 @@ export function LandingPage() {
   );
 }
 
-function HeroSection() {
+function HeroSection(): ReactElement {
   return (
     <section className="relative flex min-h-[calc(100dvh-52px)] flex-col items-center justify-center gap-6 overflow-hidden px-6 py-16 text-center">
       {/* 배경 depth — 중앙으로 갈수록 밝아지는 radial gradient */}
@@ -59,7 +61,7 @@ function HeroSection() {
   );
 }
 
-function EmotionSection() {
+function EmotionSection(): ReactElement {
   return (
     <section className="flex flex-col items-center gap-10 px-6 py-16 tablet:px-[72px]">
       <div className="w-full max-w-sm rounded-2xl bg-blue-200 px-6 py-8">
@@ -85,7 +87,7 @@ function EmotionSection() {
   );
 }
 
-function EpigramsSection() {
+function EpigramsSection(): ReactElement {
   return (
     <section className="flex flex-col gap-10 px-6 py-16 tablet:px-[72px]">
       <h2 className="text-2xl font-bold text-black-950 tablet:text-3xl">
@@ -118,7 +120,7 @@ function EpigramsSection() {
   );
 }
 
-function CtaSection() {
+function CtaSection(): ReactElement {
   return (
     <section className="flex flex-col items-center gap-8 bg-blue-950 px-6 py-20 tablet:px-[72px]">
       <div className="flex flex-col items-center gap-2">


### PR DESCRIPTION
## ✏️ 작업 내용

## 변경 사항

페이지 레이어 코드 품질 개선 (React 19 기준)

### 주요 수정

- **LandingPage**: import 순서 정리 (lucide → next), 모든 함수 반환 타입 명시 (`ReactElement`)
- **EpigramsPage**: `React` namespace 제거 → `ReactElement` named import, import 순서 정리
- **layout.tsx**: `React.ReactNode` → `ReactNode` (`import type`), import 순서 정리
- **app/page.tsx**: `React` namespace 제거, 반환 타입 명시
- **app/epigrams/page.tsx**: `React` namespace 제거, 반환 타입 명시
- **app/login/page.tsx, app/signup/page.tsx**: 반환 타입 명시 (`Promise<ReactElement>`)

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 페이지(views & app) 중간 리팩토링 기능이 추가됩니다.

Closes #122