### PR TITLE
feat: 에피그램 작성 페이지 구현 (#124)

### DIFF
--- a/src/app/addepigram/page.tsx
+++ b/src/app/addepigram/page.tsx
@@ -1,3 +1,5 @@
+import { AddEpigramPage } from "@/views/add-epigram";
+
 export default function Page() {
-  return null;
+  return <AddEpigramPage />;
 }

--- a/src/entities/epigram/api/createEpigram.ts
+++ b/src/entities/epigram/api/createEpigram.ts
@@ -1,0 +1,16 @@
+import { apiClient } from "@/shared/api/client";
+
+import type { EpigramDetail } from "../model/schema";
+
+export interface CreateEpigramRequest {
+  content: string;
+  author: string;
+  referenceTitle?: string;
+  referenceUrl?: string;
+  tags: string[];
+}
+
+export async function createEpigram(data: CreateEpigramRequest): Promise<EpigramDetail> {
+  const response = await apiClient.post<EpigramDetail>("/api/epigrams", data);
+  return response.data;
+}

--- a/src/features/epigram-create/index.ts
+++ b/src/features/epigram-create/index.ts
@@ -1,0 +1,1 @@
+export { EpigramCreateForm } from "./ui/EpigramCreateForm";

--- a/src/features/epigram-create/model/schema.ts
+++ b/src/features/epigram-create/model/schema.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+export const AUTHOR_TYPE = {
+  DIRECT: "direct",
+  UNKNOWN: "unknown",
+  SELF: "self",
+} as const;
+
+export type AuthorType = (typeof AUTHOR_TYPE)[keyof typeof AUTHOR_TYPE];
+
+export const epigramCreateFormSchema = z
+  .object({
+    content: z
+      .string()
+      .min(1, "내용을 입력해주세요.")
+      .max(500, "내용은 500자 이내로 입력해주세요."),
+    authorType: z.enum([AUTHOR_TYPE.DIRECT, AUTHOR_TYPE.UNKNOWN, AUTHOR_TYPE.SELF]),
+    authorName: z.string().max(30, "저자명은 30자 이내로 입력해주세요.").optional(),
+    referenceTitle: z.string().max(100, "출처 제목은 100자 이내로 입력해주세요.").optional(),
+    referenceUrl: z
+      .string()
+      .optional()
+      .refine(
+        (val) => !val || /^https?:\/\/.+/.test(val),
+        "올바른 URL 형식을 입력해주세요. (ex. https://www.website.com)"
+      ),
+    tags: z
+      .array(z.string().min(1).max(10, "태그는 10자 이내로 입력해주세요."))
+      .max(3, "태그는 최대 3개까지 추가할 수 있습니다."),
+  })
+  .superRefine((data, ctx) => {
+    if (data.authorType === AUTHOR_TYPE.DIRECT && !data.authorName?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "저자 이름을 입력해주세요.",
+        path: ["authorName"],
+      });
+    }
+  });
+
+export type EpigramCreateFormValues = z.infer<typeof epigramCreateFormSchema>;

--- a/src/features/epigram-create/model/useEpigramCreate.ts
+++ b/src/features/epigram-create/model/useEpigramCreate.ts
@@ -1,0 +1,66 @@
+import { useState } from "react";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+
+import { createEpigram } from "@/entities/epigram/api/createEpigram";
+
+import { AUTHOR_TYPE, type EpigramCreateFormValues } from "./schema";
+
+const MAX_TAG_LENGTH = 10;
+
+function resolveAuthor(values: EpigramCreateFormValues, userNickname: string | undefined): string {
+  if (values.authorType === AUTHOR_TYPE.UNKNOWN) return "알 수 없음";
+  if (values.authorType === AUTHOR_TYPE.SELF) return userNickname ?? "본인";
+  return values.authorName ?? "";
+}
+
+export function useEpigramCreate(userNickname?: string) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [tagInput, setTagInput] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: (values: EpigramCreateFormValues) =>
+      createEpigram({
+        content: values.content,
+        author: resolveAuthor(values, userNickname),
+        referenceTitle: values.referenceTitle?.trim() || undefined,
+        referenceUrl: values.referenceUrl?.trim() || undefined,
+        tags: values.tags,
+      }),
+    onSuccess: (epigram) => {
+      queryClient.invalidateQueries({ queryKey: ["epigrams"] });
+      router.push(`/epigrams/${epigram.id}`);
+    },
+  });
+
+  function handleTagInputChange(value: string): void {
+    setTagInput(value.slice(0, MAX_TAG_LENGTH));
+  }
+
+  function handleAddTag(currentTags: string[], onChange: (tags: string[]) => void): void {
+    const trimmed = tagInput.trim();
+    if (!trimmed || currentTags.length >= 3 || currentTags.includes(trimmed)) return;
+    onChange([...currentTags, trimmed]);
+    setTagInput("");
+  }
+
+  function handleRemoveTag(
+    tag: string,
+    currentTags: string[],
+    onChange: (tags: string[]) => void
+  ): void {
+    onChange(currentTags.filter((t) => t !== tag));
+  }
+
+  return {
+    tagInput,
+    handleTagInputChange,
+    handleAddTag,
+    handleRemoveTag,
+    submit: mutation.mutate,
+    isSubmitting: mutation.isPending,
+    submitError: mutation.error,
+  };
+}

--- a/src/features/epigram-create/ui/EpigramCreateForm.tsx
+++ b/src/features/epigram-create/ui/EpigramCreateForm.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { type KeyboardEvent, type ReactElement } from "react";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { X } from "lucide-react";
+import { useForm, Controller } from "react-hook-form";
+
+import { Button } from "@/shared/ui/Button";
+import { Input } from "@/shared/ui/Input";
+
+import { useEpigramCreate } from "../model/useEpigramCreate";
+import {
+  AUTHOR_TYPE,
+  epigramCreateFormSchema,
+  type AuthorType,
+  type EpigramCreateFormValues,
+} from "../model/schema";
+
+interface AuthorRadioOption {
+  value: AuthorType;
+  label: string;
+}
+
+const AUTHOR_OPTIONS: AuthorRadioOption[] = [
+  { value: AUTHOR_TYPE.DIRECT, label: "직접 입력" },
+  { value: AUTHOR_TYPE.UNKNOWN, label: "알 수 없음" },
+  { value: AUTHOR_TYPE.SELF, label: "본인" },
+];
+
+const MAX_CONTENT_LENGTH = 500;
+
+interface EpigramCreateFormProps {
+  userNickname?: string;
+}
+
+export function EpigramCreateForm({ userNickname }: EpigramCreateFormProps): ReactElement {
+  const {
+    register,
+    handleSubmit,
+    control,
+    watch,
+    formState: { errors },
+  } = useForm<EpigramCreateFormValues>({
+    resolver: zodResolver(epigramCreateFormSchema),
+    defaultValues: {
+      content: "",
+      authorType: AUTHOR_TYPE.DIRECT,
+      authorName: "",
+      referenceTitle: "",
+      referenceUrl: "",
+      tags: [],
+    },
+  });
+
+  const {
+    tagInput,
+    handleTagInputChange,
+    handleAddTag,
+    handleRemoveTag,
+    submit,
+    isSubmitting,
+    submitError,
+  } = useEpigramCreate(userNickname);
+
+  const contentValue = watch("content");
+  const authorType = watch("authorType");
+  const contentLength = contentValue?.length ?? 0;
+  const isContentNearLimit = contentLength >= MAX_CONTENT_LENGTH * 0.9;
+  const isContentOverLimit = contentLength > MAX_CONTENT_LENGTH;
+
+  function getContentCounterClass(): string {
+    if (isContentOverLimit) return "font-semibold text-error";
+    if (isContentNearLimit) return "text-black-300";
+    return "text-blue-400";
+  }
+
+  function handleTagKeyDown(
+    e: KeyboardEvent<HTMLInputElement>,
+    currentTags: string[],
+    onChange: (tags: string[]) => void
+  ): void {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleAddTag(currentTags, onChange);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit((values) => submit(values))}
+      className="flex flex-col gap-8"
+      noValidate
+    >
+      <fieldset className="flex flex-col gap-2">
+        <label htmlFor="content" className="text-sm font-semibold text-blue-900">
+          내용 <span className="text-error">*</span>
+        </label>
+        <div className="relative">
+          <textarea
+            id="content"
+            {...register("content")}
+            placeholder="500자 이내로 입력해주세요."
+            rows={5}
+            className={`w-full resize-none rounded-xl bg-blue-200 px-4 py-3 pb-6 text-sm text-black-950 outline-none transition-all duration-200 placeholder:text-blue-400 focus:bg-blue-100 focus:ring-2 focus:ring-black-500 ${
+              errors.content ? "bg-blue-100 ring-2 ring-error" : ""
+            }`}
+          />
+          <span
+            className={`absolute bottom-3 right-4 text-xs transition-colors duration-200 ${getContentCounterClass()}`}
+          >
+            {contentLength} / {MAX_CONTENT_LENGTH}
+          </span>
+        </div>
+        {errors.content ? (
+          <p className="animate-fade-in text-xs text-error">{errors.content.message}</p>
+        ) : null}
+      </fieldset>
+
+      <fieldset className="flex flex-col gap-3">
+        <legend className="text-sm font-semibold text-blue-900">
+          저자 <span className="text-error">*</span>
+        </legend>
+
+        <Controller
+          name="authorType"
+          control={control}
+          render={({ field }) => (
+            <div className="flex gap-6">
+              {AUTHOR_OPTIONS.map((option) => (
+                <label
+                  key={option.value}
+                  className="flex cursor-pointer items-center gap-2 text-sm text-black-500 transition-colors hover:text-black-900"
+                >
+                  <span className="relative flex h-5 w-5 shrink-0 items-center justify-center">
+                    <input
+                      type="radio"
+                      value={option.value}
+                      checked={field.value === option.value}
+                      onChange={() => field.onChange(option.value)}
+                      className="peer sr-only"
+                    />
+                    <span className="h-5 w-5 rounded-full border-2 border-blue-400 transition-colors duration-150 peer-checked:border-blue-900 peer-focus-visible:ring-2 peer-focus-visible:ring-black-500 peer-focus-visible:ring-offset-1" />
+                    <span className="absolute h-2.5 w-2.5 scale-0 rounded-full bg-blue-900 transition-transform duration-150 peer-checked:scale-100" />
+                  </span>
+                  {option.label}
+                </label>
+              ))}
+            </div>
+          )}
+        />
+
+        {authorType === AUTHOR_TYPE.DIRECT ? (
+          <div className="animate-fade-in">
+            <Input
+              {...register("authorName")}
+              placeholder="저자 이름 입력"
+              error={errors.authorName?.message}
+            />
+          </div>
+        ) : null}
+      </fieldset>
+
+      <fieldset className="flex flex-col gap-2">
+        <legend className="text-sm font-semibold text-blue-900">출처</legend>
+        <div className="flex flex-col gap-2">
+          <Input
+            {...register("referenceTitle")}
+            placeholder="출처 제목 입력"
+            error={errors.referenceTitle?.message}
+          />
+          <Input
+            {...register("referenceUrl")}
+            placeholder="URL (ex. https://www.website.com)"
+            type="url"
+            error={errors.referenceUrl?.message}
+          />
+        </div>
+      </fieldset>
+
+      <Controller
+        name="tags"
+        control={control}
+        render={({ field }) => (
+          <fieldset className="flex flex-col gap-2">
+            <legend className="text-sm font-semibold text-blue-900">태그</legend>
+
+            <div className="relative">
+              <input
+                value={tagInput}
+                onChange={(e) => handleTagInputChange(e.target.value)}
+                onKeyDown={(e) => handleTagKeyDown(e, field.value, field.onChange)}
+                placeholder="입력하여 태그 작성 (최대 10자)"
+                disabled={field.value.length >= 3}
+                className={[
+                  "h-11 w-full rounded-xl bg-blue-200 px-4 pr-20 text-sm text-black-950",
+                  "outline-none transition-all duration-200 placeholder:text-blue-400",
+                  "focus:bg-blue-100 focus:ring-2 focus:ring-black-500",
+                  "disabled:cursor-not-allowed disabled:opacity-50",
+                  errors.tags ? "bg-blue-100 ring-2 ring-error" : "",
+                ].join(" ")}
+              />
+              <button
+                type="button"
+                onClick={() => handleAddTag(field.value, field.onChange)}
+                disabled={field.value.length >= 3 || !tagInput.trim()}
+                className="absolute right-2 top-1/2 -translate-y-1/2 rounded-lg bg-blue-900 px-3 py-1 text-xs font-semibold text-white transition-all duration-150 hover:bg-black-600 active:scale-95 disabled:cursor-not-allowed disabled:bg-blue-300"
+              >
+                추가
+              </button>
+            </div>
+
+            {field.value.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {field.value.map((tag) => (
+                  <span
+                    key={tag}
+                    className="animate-fade-in flex items-center gap-1 rounded-full bg-blue-200 px-3 py-1 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-300"
+                  >
+                    #{tag}
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveTag(tag, field.value, field.onChange)}
+                      className="ml-0.5 rounded-full p-0.5 text-blue-400 transition-colors hover:bg-blue-400 hover:text-white"
+                      aria-label={`태그 '${tag}' 삭제`}
+                    >
+                      <X size={12} strokeWidth={2.5} />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            ) : null}
+
+            <p className="text-xs text-blue-400">
+              {field.value.length >= 3
+                ? "태그는 최대 3개까지 추가할 수 있습니다."
+                : `${field.value.length}/3개 추가됨`}
+            </p>
+
+            {errors.tags ? (
+              <p className="animate-fade-in text-xs text-error">{errors.tags.message}</p>
+            ) : null}
+          </fieldset>
+        )}
+      />
+
+      {submitError ? (
+        <p className="animate-fade-in rounded-xl bg-error/10 px-4 py-3 text-sm text-error">
+          에피그램 작성에 실패했습니다. 다시 시도해주세요.
+        </p>
+      ) : null}
+
+      <Button
+        type="submit"
+        isLoading={isSubmitting}
+        disabled={isContentOverLimit}
+        className="h-12 w-full text-base"
+      >
+        작성 완료
+      </Button>
+    </form>
+  );
+}

--- a/src/shared/ui/Textarea.tsx
+++ b/src/shared/ui/Textarea.tsx
@@ -1,0 +1,34 @@
+import type { TextareaHTMLAttributes, ReactElement } from "react";
+
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label?: string;
+  error?: string;
+}
+
+export function Textarea({
+  label,
+  error,
+  id,
+  className = "",
+  ...props
+}: TextareaProps): ReactElement {
+  const textareaId = id ?? label;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {label ? (
+        <label htmlFor={textareaId} className="text-sm font-medium text-blue-900">
+          {label}
+        </label>
+      ) : null}
+      <textarea
+        id={textareaId}
+        className={`w-full rounded-xl bg-blue-200 px-4 py-3 text-sm text-black-950 outline-none transition-all duration-200 placeholder:text-blue-400 focus:bg-blue-100 focus:ring-2 focus:ring-black-500 disabled:cursor-not-allowed disabled:opacity-50 ${
+          error ? "bg-blue-100 ring-2 ring-error" : ""
+        } ${className}`}
+        {...props}
+      />
+      {error ? <p className="animate-fade-in text-xs text-error">{error}</p> : null}
+    </div>
+  );
+}

--- a/src/views/add-epigram/index.ts
+++ b/src/views/add-epigram/index.ts
@@ -1,0 +1,1 @@
+export { AddEpigramPage } from "./ui/AddEpigramPage";

--- a/src/views/add-epigram/ui/AddEpigramPage.tsx
+++ b/src/views/add-epigram/ui/AddEpigramPage.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { ReactElement } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getMe } from "@/entities/user/api/user";
+import { EpigramCreateForm } from "@/features/epigram-create";
+
+export function AddEpigramPage(): ReactElement {
+  const { data: user } = useQuery({
+    queryKey: ["me"],
+    queryFn: getMe,
+  });
+
+  return (
+    <main
+      id="main-content"
+      className="mx-auto min-h-screen max-w-2xl px-4 py-10 tablet:px-6 desktop:max-w-3xl"
+    >
+      {/* 페이지 헤더 */}
+      <div className="mb-10">
+        <h1 className="text-2xl font-bold text-black-950 tablet:text-3xl">에피그램 만들기</h1>
+        <p className="mt-2 text-sm text-blue-400">
+          마음에 새겨두고 싶은 글귀를 에피그램으로 만들어보세요.
+        </p>
+      </div>
+
+      {/* 작성 폼 */}
+      <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-blue-200 tablet:p-8">
+        <EpigramCreateForm userNickname={user?.nickname} />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- `createEpigram` API 함수 구현 (T049)
- 에피그램 작성 폼 Zod 스키마 정의 — content(500자), author, tags(최대 3개/각 10자), referenceUrl 검증 (T050)
- `EpigramCreateForm` feature — 저자 라디오(직접입력/알 수 없음/본인), 태그 입력·삭제, URL 형식 검증, 500자 실시간 카운터 (T051)
- `AddEpigramPage` 및 `/addepigram` 라우트 구현 (T052)
- `Textarea` 공유 컴포넌트 추가 (Input 패턴과 일관성 유지)

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 에피그램 작성 페이지 구현 기능이 추가됩니다.

Closes #124