### PR TITLE
feat: 에피그램 댓글 목록 API 훅 useEpigramComments 구현 (#132)

### DIFF
--- a/specs/001-epigram-core-pages/tasks.md
+++ b/specs/001-epigram-core-pages/tasks.md
@@ -158,7 +158,7 @@
 
 - [x] T053 [P] [US4] Comment 엔티티 Zod 스키마 정의 (`src/entities/comment/model/schema.ts`)
 - [x] T054 [P] [US4] 에피그램 상세 조회 API 훅 — `useEpigramDetail` (`src/entities/epigram/api/useEpigramDetail.ts`)
-- [ ] T055 [P] [US4] 에피그램 댓글 목록 API 훅 — `useEpigramComments` (무한 스크롤, cursor 기반) (`src/entities/comment/api/useEpigramComments.ts`)
+- [x] T055 [P] [US4] 에피그램 댓글 목록 API 훅 — `useEpigramComments` (무한 스크롤, cursor 기반) (`src/entities/comment/api/useEpigramComments.ts`)
 
 ### US4 — Features (의존: T053~T055)
 

--- a/src/entities/comment/api/useEpigramComments.ts
+++ b/src/entities/comment/api/useEpigramComments.ts
@@ -1,0 +1,38 @@
+import {
+  useInfiniteQuery,
+  type UseInfiniteQueryResult,
+  type InfiniteData,
+} from "@tanstack/react-query";
+
+import { apiClient } from "@/shared/api/client";
+
+import type { CommentListResponse } from "../model/schema";
+
+interface UseEpigramCommentsParams {
+  epigramId: number;
+  limit: number;
+}
+
+export function useEpigramComments({
+  epigramId,
+  limit,
+}: UseEpigramCommentsParams): UseInfiniteQueryResult<
+  InfiniteData<CommentListResponse, number | undefined>,
+  Error
+> {
+  return useInfiniteQuery({
+    queryKey: ["epigrams", epigramId, "comments", { limit }],
+    enabled: epigramId > 0,
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams({ limit: String(limit) });
+      if (pageParam !== undefined) params.set("cursor", String(pageParam));
+
+      const response = await apiClient.get<CommentListResponse>(
+        `/api/epigrams/${epigramId}/comments?${params}`
+      );
+      return response.data;
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+}

--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -2,3 +2,4 @@ export { writerSchema, commentSchema, commentListResponseSchema } from "./model/
 export type { Writer, Comment, CommentListResponse } from "./model/schema";
 
 export { useRecentComments } from "./api/useRecentComments";
+export { useEpigramComments } from "./api/useEpigramComments";


### PR DESCRIPTION
## ✏️ 작업 내용

에피그램 댓글 목록 무한 스크롤 React Query 훅 구현.

- `useEpigramComments({ epigramId, limit })` — GET `/api/epigrams/:id/comments`
- `useInfiniteQuery` + cursor 기반 페이지네이션
- `enabled: epigramId > 0` 가드로 유효하지 않은 id 방지
- queryKey: `["epigrams", epigramId, "comments", { limit }]`
- `src/entities/comment/index.ts`에 export 추가

Closes #132

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 에피그램 댓글 목록 API 훅 useEpigramComments 구현 기능이 추가됩니다.

Closes #132