### PR TITLE
feat: 검색 feature 구현 - SearchBar, useSearch, useRecentSearches (#163)

### DIFF
--- a/specs/001-epigram-core-pages/tasks.md
+++ b/specs/001-epigram-core-pages/tasks.md
@@ -195,7 +195,7 @@
 
 ### US5 — Features (의존: T066)
 
-- [ ] T067 [US5] 검색 feature 구현 — 검색어 입력, URL 쿼리 파라미터 동기화(`?keyword=`), 로컬스토리지 최근 검색어 저장·삭제·모두 지우기 (`src/features/epigram-search/ui/SearchBar.tsx`, `src/features/epigram-search/model/useSearch.ts`, `src/features/epigram-search/model/useRecentSearches.ts`)
+- [x] T067 [US5] 검색 feature 구현 — 검색어 입력, URL 쿼리 파라미터 동기화(`?keyword=`), 로컬스토리지 최근 검색어 저장·삭제·모두 지우기 (`src/features/epigram-search/ui/SearchBar.tsx`, `src/features/epigram-search/model/useSearch.ts`, `src/features/epigram-search/model/useRecentSearches.ts`)
 - [ ] T068 [US5] 검색 결과 아이템 구현 — 키워드 하이라이팅(태그·에피그램 내용), 클릭 → 상세 이동 (`src/features/epigram-search/ui/SearchResultItem.tsx`)
 
 ### US5 — Pages & App Routes (의존: T067~T068)

--- a/src/features/epigram-search/index.ts
+++ b/src/features/epigram-search/index.ts
@@ -1,0 +1,3 @@
+export { useSearch } from "./model/useSearch";
+export { useRecentSearches } from "./model/useRecentSearches";
+export { SearchBar } from "./ui/SearchBar";

--- a/src/features/epigram-search/model/useRecentSearches.ts
+++ b/src/features/epigram-search/model/useRecentSearches.ts
@@ -1,0 +1,63 @@
+import { useState, useEffect, useCallback, startTransition } from "react";
+
+const STORAGE_KEY = "epigram_recent_searches";
+const MAX_RECENT_SEARCHES = 10;
+
+function loadFromStorage(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveToStorage(searches: string[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(searches));
+}
+
+interface UseRecentSearchesResult {
+  recentSearches: string[];
+  addRecentSearch: (keyword: string) => void;
+  removeRecentSearch: (keyword: string) => void;
+  clearAllRecentSearches: () => void;
+}
+
+export function useRecentSearches(): UseRecentSearchesResult {
+  const [recentSearches, setRecentSearches] = useState<string[]>([]);
+
+  // Load from localStorage after mount to avoid SSR/client hydration mismatch
+  useEffect(() => {
+    startTransition(() => {
+      setRecentSearches(loadFromStorage());
+    });
+  }, []);
+
+  const addRecentSearch = useCallback((keyword: string) => {
+    const trimmed = keyword.trim();
+    if (!trimmed) return;
+
+    setRecentSearches((prev) => {
+      const deduplicated = prev.filter((k) => k !== trimmed);
+      const updated = [trimmed, ...deduplicated].slice(0, MAX_RECENT_SEARCHES);
+      saveToStorage(updated);
+      return updated;
+    });
+  }, []);
+
+  const removeRecentSearch = useCallback((keyword: string) => {
+    setRecentSearches((prev) => {
+      const updated = prev.filter((k) => k !== keyword);
+      saveToStorage(updated);
+      return updated;
+    });
+  }, []);
+
+  const clearAllRecentSearches = useCallback(() => {
+    saveToStorage([]);
+    setRecentSearches([]);
+  }, []);
+
+  return { recentSearches, addRecentSearch, removeRecentSearch, clearAllRecentSearches };
+}

--- a/src/features/epigram-search/model/useSearch.ts
+++ b/src/features/epigram-search/model/useSearch.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, useCallback } from "react";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { useRecentSearches } from "./useRecentSearches";
+
+interface UseSearchResult {
+  inputValue: string;
+  activeKeyword: string;
+  recentSearches: string[];
+  handleInputChange: (value: string) => void;
+  handleSearch: (keyword: string) => void;
+  removeRecentSearch: (keyword: string) => void;
+  clearAllRecentSearches: () => void;
+}
+
+export function useSearch(): UseSearchResult {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const initialKeyword = searchParams.get("keyword") ?? "";
+
+  const [inputValue, setInputValue] = useState(initialKeyword);
+  const [activeKeyword, setActiveKeyword] = useState(initialKeyword);
+
+  const { recentSearches, addRecentSearch, removeRecentSearch, clearAllRecentSearches } =
+    useRecentSearches();
+
+  const handleInputChange = useCallback((value: string) => {
+    setInputValue(value);
+  }, []);
+
+  const handleSearch = useCallback(
+    (keyword: string) => {
+      const trimmed = keyword.trim();
+      if (!trimmed) return;
+
+      setInputValue(trimmed);
+      setActiveKeyword(trimmed);
+      addRecentSearch(trimmed);
+
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("keyword", trimmed);
+      router.push(`/search?${params.toString()}`);
+    },
+    [router, searchParams, addRecentSearch]
+  );
+
+  return {
+    inputValue,
+    activeKeyword,
+    recentSearches,
+    handleInputChange,
+    handleSearch,
+    removeRecentSearch,
+    clearAllRecentSearches,
+  };
+}

--- a/src/features/epigram-search/ui/SearchBar.tsx
+++ b/src/features/epigram-search/ui/SearchBar.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { type KeyboardEvent, type ReactElement } from "react";
+
+import { Search, X } from "lucide-react";
+
+interface SearchBarProps {
+  inputValue: string;
+  recentSearches: string[];
+  onInputChange: (value: string) => void;
+  onSearch: (keyword: string) => void;
+  onRemoveRecent: (keyword: string) => void;
+  onClearAllRecent: () => void;
+}
+
+function RecentSearchChip({
+  keyword,
+  onSelect,
+  onRemove,
+}: {
+  keyword: string;
+  onSelect: (keyword: string) => void;
+  onRemove: (keyword: string) => void;
+}): ReactElement {
+  return (
+    <li className="flex items-center gap-1 rounded-full bg-blue-100 px-3 py-1 text-sm text-black-600">
+      <button type="button" onClick={() => onSelect(keyword)} className="hover:text-black-950">
+        {keyword}
+      </button>
+      <button
+        type="button"
+        aria-label={`${keyword} 검색어 삭제`}
+        onClick={() => onRemove(keyword)}
+        className="flex items-center text-blue-400 hover:text-black-500"
+      >
+        <X size={12} />
+      </button>
+    </li>
+  );
+}
+
+export function SearchBar({
+  inputValue,
+  recentSearches,
+  onInputChange,
+  onSearch,
+  onRemoveRecent,
+  onClearAllRecent,
+}: SearchBarProps): ReactElement {
+  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>): void {
+    if (e.key === "Enter") {
+      onSearch(inputValue);
+    }
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <div className="relative flex items-center">
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => onInputChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="검색어를 입력하세요"
+          className="h-12 w-full rounded-full border border-blue-200 bg-white px-5 pr-12 text-sm text-black-950 outline-none placeholder:text-blue-300 focus:border-black-500"
+        />
+        <button
+          type="button"
+          aria-label="검색"
+          onClick={() => onSearch(inputValue)}
+          className="absolute right-4 text-blue-300 hover:text-black-500"
+        >
+          <Search size={20} />
+        </button>
+      </div>
+
+      {recentSearches.length > 0 ? (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-black-600">최근 검색어</span>
+            <button
+              type="button"
+              onClick={onClearAllRecent}
+              className="text-xs text-blue-400 hover:text-black-500"
+            >
+              모두 제거
+            </button>
+          </div>
+          <ul className="flex flex-wrap gap-2">
+            {recentSearches.map((keyword) => (
+              <RecentSearchChip
+                key={keyword}
+                keyword={keyword}
+                onSelect={onSearch}
+                onRemove={onRemoveRecent}
+              />
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- `useRecentSearches` — 로컬스토리지 기반 최근 검색어 관리 (추가/삭제/전체삭제)
- `useSearch` — 검색어 입력 상태 + URL `?keyword=` 쿼리 파라미터 동기화
- `SearchBar` — 피그마 시안 기반 검색 인풋 UI (Search 아이콘, 최근 검색어 칩 목록)

## 🗨️ 논의 사항 (참고 사항)

- `startTransition`으로 localStorage 초기화 — SSR hydration mismatch 방지 및 lint 에러 해결
- `inputValue` (현재 타이핑 값) / `activeKeyword` (마지막 검색 확정 키워드) 분리하여 T069 SearchPage에서 사용 가능하도록 설계

## 기대효과

검색어 입력 → URL 반영, 최근 검색어 로컬스토리지 저장·삭제·전체삭제 기능 완성.
T069 (검색 페이지) 구현 시 SearchBar + useSearch를 조합하여 바로 사용 가능.

Closes #163