### PR TITLE
refactor: 검색 페이지 코드 리뷰 기반 리팩토링 (#169)

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,11 +1,10 @@
-import { Suspense } from "react";
+import { type ReactElement, Suspense } from "react";
 
 import { SearchPage } from "@/views/search";
 
-// 검색 페이지는 URL searchParams 기반이므로 force-dynamic
 export const dynamic = "force-dynamic";
 
-export default function Page() {
+export default function Page(): ReactElement {
   return (
     <Suspense>
       <SearchPage />

--- a/src/features/epigram-search/model/useRecentSearches.ts
+++ b/src/features/epigram-search/model/useRecentSearches.ts
@@ -27,7 +27,8 @@ interface UseRecentSearchesResult {
 export function useRecentSearches(): UseRecentSearchesResult {
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
 
-  // Load from localStorage after mount to avoid SSR/client hydration mismatch
+  // Load from localStorage after mount to avoid SSR/client hydration mismatch.
+  // startTransition: marks this low-priority so React can yield to urgent updates (e.g. input focus)
   useEffect(() => {
     startTransition(() => {
       setRecentSearches(loadFromStorage());

--- a/src/features/epigram-search/model/useSearch.ts
+++ b/src/features/epigram-search/model/useSearch.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState } from "react";
 
 import { useRouter, useSearchParams } from "next/navigation";
 
@@ -19,33 +19,30 @@ interface UseSearchResult {
 export function useSearch(): UseSearchResult {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const initialKeyword = searchParams.get("keyword") ?? "";
 
-  const [inputValue, setInputValue] = useState(initialKeyword);
-  const [activeKeyword, setActiveKeyword] = useState(initialKeyword);
+  // URL이 단일 진실 공급원 — 별도 상태 없이 직접 파생
+  const activeKeyword = searchParams.get("keyword") ?? "";
+
+  const [inputValue, setInputValue] = useState(activeKeyword);
 
   const { recentSearches, addRecentSearch, removeRecentSearch, clearAllRecentSearches } =
     useRecentSearches();
 
-  const handleInputChange = useCallback((value: string) => {
+  function handleInputChange(value: string): void {
     setInputValue(value);
-  }, []);
+  }
 
-  const handleSearch = useCallback(
-    (keyword: string) => {
-      const trimmed = keyword.trim();
-      if (!trimmed) return;
+  function handleSearch(keyword: string): void {
+    const trimmed = keyword.trim();
+    if (!trimmed) return;
 
-      setInputValue(trimmed);
-      setActiveKeyword(trimmed);
-      addRecentSearch(trimmed);
+    setInputValue(trimmed);
+    addRecentSearch(trimmed);
 
-      const params = new URLSearchParams(searchParams.toString());
-      params.set("keyword", trimmed);
-      router.push(`/search?${params.toString()}`);
-    },
-    [router, searchParams, addRecentSearch]
-  );
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("keyword", trimmed);
+    router.push(`/search?${params.toString()}`);
+  }
 
   return {
     inputValue,

--- a/src/features/epigram-search/ui/SearchBar.tsx
+++ b/src/features/epigram-search/ui/SearchBar.tsx
@@ -60,7 +60,6 @@ export function SearchBar({
 
   return (
     <div className="flex w-full flex-col gap-6 pc:gap-8">
-      {/* 언더라인 스타일 검색 입력 */}
       <div className="group relative flex items-center border-b-2 border-blue-300 pb-2 transition-colors duration-200 focus-within:border-black-700 pc:pb-3">
         <input
           type="search"
@@ -83,7 +82,6 @@ export function SearchBar({
         </button>
       </div>
 
-      {/* 최근 검색어 */}
       {recentSearches.length > 0 && (
         <div className="animate-fade-in flex flex-col gap-3 pc:gap-4">
           <div className="flex items-center justify-between">

--- a/src/features/epigram-search/ui/SearchResultItem.tsx
+++ b/src/features/epigram-search/ui/SearchResultItem.tsx
@@ -24,7 +24,7 @@ function buildHighlightedSegments(text: string, regex: RegExp): ReactNode {
     index % 2 === 1 ? (
       <mark
         key={index}
-        className="font-serif rounded-sm bg-transparent px-0 font-semibold text-blue-700 not-italic"
+        className="rounded-sm bg-transparent px-0 font-semibold text-blue-700 not-italic"
       >
         {part}
       </mark>
@@ -60,7 +60,7 @@ function TagList({ tags, keyword }: TagListProps): ReactElement | null {
     >
       {tags.map((tag) => (
         <li key={tag.id}>
-          <span className="font-seriftext-xs font-medium text-blue-500 transition-colors duration-150 group-hover:text-blue-600 pc:text-sm">
+          <span className="text-xs font-medium text-blue-500 transition-colors duration-150 group-hover:text-blue-600 pc:text-sm">
             #<HighlightedText text={tag.name} keyword={keyword} />
           </span>
         </li>
@@ -70,7 +70,6 @@ function TagList({ tags, keyword }: TagListProps): ReactElement | null {
 }
 
 export function SearchResultItem({ epigram, keyword }: SearchResultItemProps): ReactElement {
-  // 피그마 시안: "- 저자 -" 혹은 "- 저자 《출처》 -" 형식, 좌측 배치
   const authorLabel = epigram.referenceTitle
     ? `${epigram.author} 《${epigram.referenceTitle}》`
     : epigram.author;
@@ -82,8 +81,7 @@ export function SearchResultItem({ epigram, keyword }: SearchResultItemProps): R
         tablet:px-2 tablet:py-7
         pc:px-3 pc:py-9"
     >
-      <article className="flex flex-col gap-3 pc:gap-2 ">
-        {/* 에피그램 본문 */}
+      <article className="flex flex-col gap-3 pc:gap-2">
         <p
           className="font-serif text-sm leading-relaxed text-black-700 transition-colors duration-150 group-hover:text-black-950
             tablet:text-base tablet:leading-loose
@@ -92,11 +90,8 @@ export function SearchResultItem({ epigram, keyword }: SearchResultItemProps): R
           <HighlightedText text={epigram.content} keyword={keyword} />
         </p>
 
-        {/* 피그마 레이아웃: 좌측 저자 / 우측 태그 한 행 */}
         <div className="flex items-start justify-between gap-4">
-          <footer className="font-sans shrink-0 text-xs text-black-300 pc:text-sm">
-            - {authorLabel} -
-          </footer>
+          <footer className="shrink-0 text-xs text-black-300 pc:text-sm">- {authorLabel} -</footer>
           <TagList tags={epigram.tags} keyword={keyword} />
         </div>
       </article>

--- a/src/views/search/ui/SearchPage.tsx
+++ b/src/views/search/ui/SearchPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactElement, useMemo } from "react";
+import { type ReactElement } from "react";
 
 import { ArrowUp, Loader2, SearchX } from "lucide-react";
 
@@ -16,8 +16,8 @@ const SEARCH_LIMIT = 10;
 function SearchResultSkeletonItem(): ReactElement {
   return (
     <div className="animate-pulse space-y-3 border-b border-line-100 py-7 last:border-0 pc:py-9">
-      <div className="h-3.5 rounded-md bg-blue-200/40 w-4/5 pc:h-4" />
-      <div className="h-3.5 rounded-md bg-blue-200/40 w-1/2 pc:h-4" />
+      <div className="h-3.5 w-4/5 rounded-md bg-blue-200/40 pc:h-4" />
+      <div className="h-3.5 w-1/2 rounded-md bg-blue-200/40 pc:h-4" />
       <div className="flex gap-2 pt-1">
         <div className="h-5 w-14 rounded-full bg-blue-200/30" />
         <div className="h-5 w-20 rounded-full bg-blue-200/30" />
@@ -38,7 +38,11 @@ function SearchResultSkeleton(): ReactElement {
 
 // ─── Empty / Initial states ───────────────────────────────────────────────────
 
-function EmptyState({ keyword }: { keyword: string }): ReactElement {
+interface EmptyStateProps {
+  keyword: string;
+}
+
+function EmptyState({ keyword }: EmptyStateProps): ReactElement {
   return (
     <div className="flex flex-col items-center gap-5 py-24 text-center pc:gap-6 pc:py-32">
       <div className="flex h-16 w-16 items-center justify-center rounded-full bg-blue-200/40 pc:h-20 pc:w-20">
@@ -92,13 +96,17 @@ function ScrollToTopButton({
 
 // ─── Search results list (infinite scroll) ────────────────────────────────────
 
-function SearchResults({ keyword }: { keyword: string }): ReactElement {
+interface SearchResultsProps {
+  keyword: string;
+}
+
+function SearchResults({ keyword }: SearchResultsProps): ReactElement {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useSearchEpigrams({
     keyword,
     limit: SEARCH_LIMIT,
   });
 
-  // useIntersectionObserver stores the callback in a ref — no need for useCallback
+  // useIntersectionObserver stores the callback in a ref internally — useCallback not needed
   const sentinelRef = useIntersectionObserver(
     () => {
       if (hasNextPage && !isFetchingNextPage) {
@@ -108,8 +116,7 @@ function SearchResults({ keyword }: { keyword: string }): ReactElement {
     { rootMargin: "300px" }
   );
 
-  // Avoid re-creating the flattened list on every render
-  const epigrams = useMemo(() => data?.pages.flatMap((page) => page.list) ?? [], [data?.pages]);
+  const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
 
   if (isLoading) return <SearchResultSkeleton />;
 
@@ -118,7 +125,11 @@ function SearchResults({ keyword }: { keyword: string }): ReactElement {
   return (
     <div>
       <p className="mb-5 text-xs font-medium text-black-300 pc:mb-7 pc:text-sm">
-        검색 결과 <span className="font-semibold text-blue-700">{epigrams.length}+</span>
+        검색 결과{" "}
+        <span className="font-semibold text-blue-700">
+          {epigrams.length}
+          {hasNextPage ? "+" : ""}
+        </span>
       </p>
 
       <ul className="divide-y divide-line-200" aria-label="검색 결과 목록">


### PR DESCRIPTION
## ✏️ 작업 내용

코드 리뷰(#168) 결과 발견된 버그 및 품질 이슈 수정

**Bug fix**
- `SearchResultItem` 태그 span `font-seriftext-xs` → `text-xs` (공백 누락으로 Tailwind 클래스 2개 모두 미적용되던 버그)
- `SearchResultItem` / `SearchBar` WHAT 주석 제거

**Code quality**
- `useSearch`: `activeKeyword`를 별도 `useState`에서 `searchParams.get("keyword")`로 직접 파생 — URL이 단일 진실 공급원, 브라우저 뒤로가기 시 상태/URL 불일치 문제 해소
- `useSearch`: `handleInputChange` / `handleSearch` 불필요한 `useCallback` 제거 (조기 최적화)
- `SearchPage`: `useMemo(flatMap)` 제거 — `data?.pages`가 참조 불안정하여 매 렌더마다 재실행, 효과 없음
- `SearchPage`: `EmptyState` / `SearchResults` props 인라인 타입 → `interface` 명시적 정의
- `app/search/page.tsx`: 최상위 함수 `Page` 반환 타입 `ReactElement` 추가

## 🗨️ 논의 사항 (참고 사항)

- `useRecentSearches`의 `startTransition` — 린터(react-hooks) 규칙(`Calling setState synchronously within an effect`) 회피 목적으로 유지. 제거 시 lint error 발생
- `ScrollToTopButton` 중복(`EpigramsPage` 동일 컴포넌트) — 별도 shared 추출은 다음 리팩토링으로 분리

## 기대효과

- 태그 텍스트 스타일 정상 적용
- URL ↔ 검색 상태 단일 진실 공급원으로 브라우저 히스토리 탐색 시 일관성 보장

Closes #169