### PR TITLE
feat: 내 댓글 목록 API 훅 구현 (useMyComments) (#175)

### DIFF
--- a/specs/001-epigram-core-pages/tasks.md
+++ b/specs/001-epigram-core-pages/tasks.md
@@ -216,7 +216,7 @@
 
 - [x] T070 [P] [US6] 월별 감정 조회 API 훅 — `useMonthlyEmotions` (userId 필수, year, month 파라미터 — swagger `GET /emotion-logs?userId=&year=&month=`) (`src/entities/emotion-log/api/useMonthlyEmotions.ts`)
 - [N/A] T071 [P] [US6] ~~내 에피그램 목록 API 훅 — `useMyEpigrams`~~ — `useEpigrams({ writerId })` 로 동일 기능 처리 가능. 별도 훅 불필요.
-- [ ] T072 [P] [US6] 내 댓글 목록 API 훅 — `useMyComments` (cursor 기반, swagger `GET /users/{id}/comments`) (`src/entities/comment/api/useMyComments.ts`)
+- [x] T072 [P] [US6] 내 댓글 목록 API 훅 — `useMyComments` (cursor 기반, swagger `GET /users/{id}/comments`) (`src/entities/comment/api/useMyComments.ts`)
 - [ ] T073 [P] [US6] 프로필 수정 API 함수 — `updateMe` (닉네임, 이미지 URL) (`src/entities/user/api/updateMe.ts`)
 - [ ] T074 [P] [US6] 이미지 업로드 API 함수 — `uploadImage` (multipart/form-data, 영문 파일명 검증) (`src/shared/api/uploadImage.ts`)
 

--- a/src/entities/comment/api/useMyComments.ts
+++ b/src/entities/comment/api/useMyComments.ts
@@ -1,0 +1,38 @@
+import {
+  useInfiniteQuery,
+  type UseInfiniteQueryResult,
+  type InfiniteData,
+} from "@tanstack/react-query";
+
+import { apiClient } from "@/shared/api/client";
+
+import type { CommentListResponse } from "../model/schema";
+
+interface UseMyCommentsParams {
+  userId: number;
+  limit: number;
+}
+
+export function useMyComments({
+  userId,
+  limit,
+}: UseMyCommentsParams): UseInfiniteQueryResult<
+  InfiniteData<CommentListResponse, number | undefined>,
+  Error
+> {
+  return useInfiniteQuery({
+    queryKey: ["users", userId, "comments", { limit }],
+    enabled: userId > 0,
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams({ limit: String(limit) });
+      if (pageParam !== undefined) params.set("cursor", String(pageParam));
+
+      const response = await apiClient.get<CommentListResponse>(
+        `/api/users/${userId}/comments?${params}`
+      );
+      return response.data;
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+}

--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -3,6 +3,7 @@ export type { Writer, Comment, CommentListResponse } from "./model/schema";
 
 export { useRecentComments } from "./api/useRecentComments";
 export { useEpigramComments } from "./api/useEpigramComments";
+export { useMyComments } from "./api/useMyComments";
 
 export { WriterAvatar } from "./ui/WriterAvatar";
 export { UserProfileModal } from "./ui/UserProfileModal";


### PR DESCRIPTION
## ✏️ 작업 내용

- `useMyComments` React Query infinite query 훅 구현
- 엔드포인트: `GET /users/{id}/comments?limit=&cursor=`
- `userId > 0` guard로 인증 전 불필요한 요청 방지
- `src/entities/comment/index.ts` export 추가

## 🗨️ 논의 사항 (참고 사항)

없음

## 기대효과

마이페이지에서 내 댓글 목록을 cursor 기반 무한 스크롤로 조회 가능

Closes #175