### PR TITLE
feat: 프로필 수정 API 함수 구현 (updateMe) (#177)

### DIFF
--- a/specs/001-epigram-core-pages/tasks.md
+++ b/specs/001-epigram-core-pages/tasks.md
@@ -217,7 +217,7 @@
 - [x] T070 [P] [US6] 월별 감정 조회 API 훅 — `useMonthlyEmotions` (userId 필수, year, month 파라미터 — swagger `GET /emotion-logs?userId=&year=&month=`) (`src/entities/emotion-log/api/useMonthlyEmotions.ts`)
 - [N/A] T071 [P] [US6] ~~내 에피그램 목록 API 훅 — `useMyEpigrams`~~ — `useEpigrams({ writerId })` 로 동일 기능 처리 가능. 별도 훅 불필요.
 - [x] T072 [P] [US6] 내 댓글 목록 API 훅 — `useMyComments` (cursor 기반, swagger `GET /users/{id}/comments`) (`src/entities/comment/api/useMyComments.ts`)
-- [ ] T073 [P] [US6] 프로필 수정 API 함수 — `updateMe` (닉네임, 이미지 URL) (`src/entities/user/api/updateMe.ts`)
+- [x] T073 [P] [US6] 프로필 수정 API 함수 — `updateMe` (닉네임, 이미지 URL) (`src/entities/user/api/user.ts` 에 통합)
 - [ ] T074 [P] [US6] 이미지 업로드 API 함수 — `uploadImage` (multipart/form-data, 영문 파일명 검증) (`src/shared/api/uploadImage.ts`)
 
 ### US6 — Features (의존: T070~T074)

--- a/src/entities/user/api/user.ts
+++ b/src/entities/user/api/user.ts
@@ -2,7 +2,17 @@ import { apiClient } from "@/shared/api/client";
 
 import { userSchema, type User } from "../model/schema";
 
+export interface UpdateMeBody {
+  nickname?: string;
+  image?: string;
+}
+
 export async function getMe(): Promise<User> {
   const response = await apiClient.get("/api/users/me");
+  return userSchema.parse(response.data);
+}
+
+export async function updateMe(body: UpdateMeBody): Promise<User> {
+  const response = await apiClient.patch("/api/users/me", body);
   return userSchema.parse(response.data);
 }

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -8,4 +8,5 @@ export { signUp, signIn, logout } from "./api/auth";
 export type { SignUpBody, SignInBody } from "./api/auth";
 export { signInKakao } from "./api/kakao";
 export type { SignInKakaoBody } from "./api/kakao";
-export { getMe } from "./api/user";
+export { getMe, updateMe } from "./api/user";
+export type { UpdateMeBody } from "./api/user";


### PR DESCRIPTION
## ✏️ 작업 내용

- `updateMe(body: UpdateMeBody): Promise<User>` 함수 구현
- 엔드포인트: `PATCH /users/me` (body: `{ nickname?, image? }`)
- `user.ts`에 `getMe`와 함께 통합 (같은 리소스, 같은 임포트)
- Zod 런타임 검증으로 응답 파싱

## 🗨️ 논의 사항 (참고 사항)

없음

## 기대효과

마이페이지에서 닉네임·프로필 이미지 수정 기능 구현에 필요한 API 함수 제공

Closes #177