### PR TITLE
feat: 프로필 이미지 변경 feature 구현 (ProfileImageUpload) (#181)

### DIFF
--- a/specs/001-epigram-core-pages/tasks.md
+++ b/specs/001-epigram-core-pages/tasks.md
@@ -214,15 +214,15 @@
 
 ### US6 — API 레이어
 
-- [ ] T070 [P] [US6] 월별 감정 조회 API 훅 — `useMonthlyEmotions` (userId 필수, year, month 파라미터 — swagger `GET /emotion-logs?userId=&year=&month=`) (`src/entities/emotion-log/api/useMonthlyEmotions.ts`)
-- [ ] T071 [P] [US6] 내 에피그램 목록 API 훅 — `useMyEpigrams` (writerId 필터, cursor 기반) (`src/entities/epigram/api/useMyEpigrams.ts`)
+- [x] T070 [P] [US6] 월별 감정 조회 API 훅 — `useMonthlyEmotions` (userId 필수, year, month 파라미터 — swagger `GET /emotion-logs?userId=&year=&month=`) (`src/entities/emotion-log/api/useMonthlyEmotions.ts`)
+- [x] T071 [P] [US6] 내 에피그램 목록 API 훅 — `useMyEpigrams` (writerId 필터, cursor 기반) (`src/entities/epigram/api/useMyEpigrams.ts`)
 - [x] T072 [P] [US6] 내 댓글 목록 API 훅 — `useMyComments` (cursor 기반, swagger `GET /users/{id}/comments`) (`src/entities/comment/api/useMyComments.ts`)
 - [x] T073 [P] [US6] 프로필 수정 API 함수 — `updateMe` (닉네임, 이미지 URL) (`src/entities/user/api/user.ts` 에 통합)
 - [x] T074 [P] [US6] 이미지 업로드 API 함수 — `uploadImage` (multipart/form-data, 영문 파일명 검증) (`src/shared/api/uploadImage.ts`)
 
 ### US6 — Features (의존: T070~T074)
 
-- [ ] T075 [P] [US6] 프로필 이미지 변경 feature 구현 — 파일 선택 → 업로드 → 프로필 수정 API 호출, 한글 파일명 경고 (`src/features/auth/ui/ProfileImageUpload.tsx`)
+- [x] T075 [P] [US6] 프로필 이미지 변경 feature 구현 — 파일 선택 → 업로드 → 프로필 수정 API 호출, 한글 파일명 경고 (`src/features/auth/ui/ProfileImageUpload.tsx`)
 - [ ] T076 [P] [US6] 감정 달력 컴포넌트 구현 — react-calendar 활용, 월별 날짜에 감정 이모지 표시, 월 이동 (`src/widgets/mypage-activity/ui/EmotionCalendar.tsx`)
 - [ ] T077 [P] [US6] 감정 파이 차트 컴포넌트 구현 — recharts 활용, 5가지 감정 비율 집계 및 시각화 (`src/widgets/mypage-activity/ui/EmotionPieChart.tsx`)
 

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -2,3 +2,4 @@ export { AuthLeftPanel } from "./ui/AuthLeftPanel";
 export { LoginForm } from "./ui/LoginForm";
 export { SignUpForm } from "./ui/SignUpForm";
 export { useLogout } from "./api/logout";
+export { ProfileImageUpload } from "./ui/ProfileImageUpload";

--- a/src/features/auth/ui/ProfileImageUpload.tsx
+++ b/src/features/auth/ui/ProfileImageUpload.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { Camera, Loader2 } from "lucide-react";
+
+import { updateMe } from "@/entities/user/api/user";
+import { uploadImage } from "@/shared/api/uploadImage";
+
+interface ProfileImageUploadProps {
+  currentImageUrl: string | null;
+  nickname: string;
+}
+
+export function ProfileImageUpload({
+  currentImageUrl,
+  nickname,
+}: ProfileImageUploadProps): React.ReactElement {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const queryClient = useQueryClient();
+
+  const [isUploading, setIsUploading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const displayUrl = previewUrl ?? currentImageUrl;
+
+  function handleAvatarClick(): void {
+    if (isUploading) return;
+    inputRef.current?.click();
+  }
+
+  async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>): Promise<void> {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setErrorMessage(null);
+    event.target.value = "";
+
+    const objectUrl = URL.createObjectURL(file);
+    setPreviewUrl(objectUrl);
+    setIsUploading(true);
+
+    try {
+      const imageUrl = await uploadImage(file);
+      await updateMe({ image: imageUrl });
+      // Clear preview so displayUrl falls back to the new currentImageUrl from parent
+      setPreviewUrl(null);
+      URL.revokeObjectURL(objectUrl);
+      // Non-blocking: UI already shows the cleared preview
+      void queryClient.invalidateQueries({ queryKey: ["me"] });
+    } catch (error) {
+      setPreviewUrl(null);
+      URL.revokeObjectURL(objectUrl);
+      setErrorMessage(
+        error instanceof Error ? error.message : "이미지 업로드에 실패했습니다. 다시 시도해주세요."
+      );
+    } finally {
+      setIsUploading(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <button
+        type="button"
+        aria-label="프로필 이미지 변경"
+        onClick={handleAvatarClick}
+        disabled={isUploading}
+        className="group relative h-[80px] w-[80px] overflow-hidden rounded-full border-2 border-line-200 bg-blue-200 transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {displayUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={displayUrl}
+            alt={`${nickname} 프로필 이미지`}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <DefaultAvatar nickname={nickname} />
+        )}
+
+        <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
+          {isUploading ? (
+            <Loader2 className="h-6 w-6 animate-spin text-white" />
+          ) : (
+            <Camera className="h-6 w-6 text-white" />
+          )}
+        </div>
+      </button>
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleFileChange}
+        aria-hidden="true"
+        tabIndex={-1}
+      />
+
+      {errorMessage && (
+        <p role="alert" className="max-w-[240px] text-center text-xs text-error">
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface DefaultAvatarProps {
+  nickname: string;
+}
+
+function DefaultAvatar({ nickname }: DefaultAvatarProps): React.ReactElement {
+  const initial = nickname.at(0)?.toUpperCase() ?? "?";
+
+  return (
+    <span className="flex h-full w-full items-center justify-center text-2xl font-semibold text-blue-600">
+      {initial}
+    </span>
+  );
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- 프로필 아바타 클릭 → 파일 선택 다이얼로그 열림
- 한글(비ASCII) 파일명 시 uploadImage 에서 에러 메시지 표시
- 업로드 중 로딩 스피너 오버레이, 완료 후 쿼리 캐시 무효화
- Object URL 누수 버그 수정 (성공/실패 모두 revokeObjectURL 후 preview 초기화)

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 프로필 이미지 변경 feature 구현 (ProfileImageUpload) 기능이 추가됩니다.

Closes #181