### PR TITLE
feat: 마이페이지 구현 (MypagePage) (#189)

### DIFF
--- a/specs/001-epigram-core-pages/tasks.md
+++ b/specs/001-epigram-core-pages/tasks.md
@@ -229,7 +229,7 @@
 ### US6 — Widgets & Pages (의존: T075~T077)
 
 - [x] T078 [US6] 마이페이지 활동 위젯 구현 — 감정 달력 + 파이 차트 + 내 에피그램(더보기 버튼) + 내 댓글(더보기 버튼, 댓글 수 표시) (`src/widgets/mypage-activity/ui/MypageActivity.tsx`, `src/widgets/mypage-activity/index.ts`)
-- [ ] T079 [US6] 마이페이지 구현 — 로그아웃 버튼, 프로필 이미지 클릭 업로드, 댓글 클릭 → 해당 에피그램 상세 이동 (`src/views/mypage/ui/MypagePage.tsx`, `src/app/mypage/page.tsx`)
+- [x] T079 [US6] 마이페이지 구현 — 로그아웃 버튼, 프로필 이미지 클릭 업로드, 댓글 클릭 → 해당 에피그램 상세 이동 (`src/views/mypage/ui/MypagePage.tsx`, `src/app/mypage/page.tsx`)
 
 **체크포인트**: 이미지 업로드(영문 파일) → 프로필 갱신 → 감정 달력 월 이동 → 파이 차트 정상 표시 → 내 에피그램 더보기 → 클릭 → 상세 이동
 

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,3 +1,5 @@
+import { MypagePage } from "@/views/mypage";
+
 export default function Page() {
-  return null;
+  return <MypagePage />;
 }

--- a/src/views/mypage/index.ts
+++ b/src/views/mypage/index.ts
@@ -1,0 +1,1 @@
+export { MypagePage } from "./ui/MypagePage";

--- a/src/views/mypage/ui/MypagePage.tsx
+++ b/src/views/mypage/ui/MypagePage.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import type { ReactElement } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+import { LogOut } from "lucide-react";
+
+import { getMe } from "@/entities/user";
+import { ProfileImageUpload } from "@/features/auth";
+import { useLogout } from "@/features/auth";
+import { MypageActivity } from "@/widgets/mypage-activity";
+
+function ProfileSkeleton(): ReactElement {
+  return (
+    <div className="animate-pulse">
+      <div className="mx-auto h-20 w-20 rounded-full bg-blue-200" />
+      <div className="mx-auto mt-3 h-5 w-24 rounded-lg bg-blue-200" />
+    </div>
+  );
+}
+
+export function MypagePage(): ReactElement {
+  const { data: me, isLoading } = useQuery({ queryKey: ["me"], queryFn: getMe });
+  const { handleLogout } = useLogout();
+
+  return (
+    <main
+      id="main-content"
+      className="mx-auto min-h-screen max-w-2xl px-4 py-10 tablet:px-6 desktop:max-w-3xl"
+    >
+      <section className="mb-8 flex flex-col items-center gap-3">
+        {isLoading || !me ? (
+          <ProfileSkeleton />
+        ) : (
+          <>
+            <ProfileImageUpload currentImageUrl={me.image} nickname={me.nickname} />
+            <p className="text-lg font-semibold text-black-700">{me.nickname}</p>
+          </>
+        )}
+
+        <button
+          type="button"
+          onClick={() => void handleLogout()}
+          className="mt-1 flex items-center gap-1.5 rounded-full border border-line-200 px-4 py-1.5 text-sm text-black-400 transition-colors hover:border-red-300 hover:text-red-500"
+        >
+          <LogOut className="h-4 w-4" aria-hidden="true" />
+          로그아웃
+        </button>
+      </section>
+
+      {me && <MypageActivity userId={me.id} />}
+    </main>
+  );
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- `MypagePage` 구현 — 프로필 이미지 업로드 + 닉네임 + 로그아웃 버튼 + `MypageActivity` 위젯 통합
- 로그아웃 버튼 클릭 시 로그아웃 후 홈(`/`)으로 이동
- 프로필 이미지 클릭 시 파일 선택 → 업로드 → 프로필 갱신 (ProfileImageUpload 재사용)
- `src/app/mypage/page.tsx` — `MypagePage` 렌더링하도록 업데이트
- `src/views/mypage/index.ts` — 퍼블릭 API 추가

## 🗨️ 논의 사항 (참고 사항)



## 기대효과

이 PR이 머지되면 마이페이지 구현 (MypagePage) 기능이 추가됩니다.

Closes #189