### PR TITLE
feat: 마이페이지 UI/UX 디자인 개선 (#191)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -140,12 +140,15 @@ body {
 }
 .emotion-calendar .react-calendar__month-view__weekdays {
   text-align: center;
+  margin-bottom: 4px;
 }
 .emotion-calendar .react-calendar__month-view__weekdays__weekday {
-  padding: 6px 0;
-  font-size: 12px;
-  font-weight: 500;
-  color: #787878;
+  padding: 5px 0;
+  font-size: 11px;
+  font-weight: 600;
+  color: #8b9dbc;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 .emotion-calendar .react-calendar__month-view__weekdays__weekday abbr {
   text-decoration: none;
@@ -161,11 +164,17 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.15s;
+  transition:
+    background 0.15s,
+    transform 0.1s;
 }
 .emotion-calendar .react-calendar__tile:hover {
   background: #eceff4;
   border-radius: 50%;
+  transform: scale(1.08);
+}
+.emotion-calendar .react-calendar__tile:active {
+  transform: scale(0.93);
 }
 .emotion-calendar .react-calendar__tile--now {
   background: transparent;
@@ -174,7 +183,7 @@ body {
   box-shadow: inset 0 0 0 1.5px #e46e80;
   border-radius: 8px;
   color: #e46e80;
-  font-weight: 600;
+  font-weight: 700;
 }
 .emotion-calendar .react-calendar__tile--active {
   background: transparent;

--- a/src/views/mypage/ui/MypagePage.tsx
+++ b/src/views/mypage/ui/MypagePage.tsx
@@ -2,53 +2,164 @@
 
 import type { ReactElement } from "react";
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { LogOut } from "lucide-react";
 
+import { postTodayEmotion, useTodayEmotion } from "@/entities/emotion-log";
+import type { Emotion } from "@/entities/emotion-log";
 import { getMe } from "@/entities/user";
-import { ProfileImageUpload } from "@/features/auth";
-import { useLogout } from "@/features/auth";
+import { ProfileImageUpload, useLogout } from "@/features/auth";
 import { MypageActivity } from "@/widgets/mypage-activity";
+
+const EMOTION_OPTIONS: { value: Emotion; emoji: string; label: string }[] = [
+  { value: "MOVED", emoji: "🥹", label: "감동" },
+  { value: "HAPPY", emoji: "😊", label: "기쁨" },
+  { value: "WORRIED", emoji: "😟", label: "고민" },
+  { value: "SAD", emoji: "😔", label: "슬픔" },
+  { value: "ANGRY", emoji: "😡", label: "분노" },
+];
+
+// Computed once at module load — date does not change during a session
+const TODAY_LABEL = new Date().toLocaleDateString("ko-KR", {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+// ─── Skeletons ────────────────────────────────────────────────────────────────
 
 function ProfileSkeleton(): ReactElement {
   return (
-    <div className="animate-pulse">
-      <div className="mx-auto h-20 w-20 rounded-full bg-blue-200" />
-      <div className="mx-auto mt-3 h-5 w-24 rounded-lg bg-blue-200" />
+    <div className="animate-pulse flex flex-col items-center gap-3">
+      <div className="h-[100px] w-[100px] rounded-full bg-blue-200" />
+      <div className="h-5 w-28 rounded-lg bg-blue-200" />
+      <div className="h-7 w-20 rounded-full bg-blue-200" />
     </div>
   );
 }
 
+// ─── Emotion Selector ─────────────────────────────────────────────────────────
+
+interface EmotionSelectorProps {
+  selectedEmotion: Emotion | null;
+  onSelect: (emotion: Emotion) => void;
+  isPending: boolean;
+}
+
+function EmotionSelector({
+  selectedEmotion,
+  onSelect,
+  isPending,
+}: EmotionSelectorProps): ReactElement {
+  return (
+    <div className="w-full rounded-2xl bg-white px-5 py-5 shadow-sm ring-1 ring-line-200">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-black-600">오늘의 감정</h2>
+        <span className="text-xs text-black-300">{TODAY_LABEL}</span>
+      </div>
+
+      <div className="flex items-center justify-around gap-1">
+        {EMOTION_OPTIONS.map(({ value, emoji, label }) => {
+          const isSelected = selectedEmotion === value;
+          return (
+            <button
+              key={value}
+              type="button"
+              onClick={() => onSelect(value)}
+              disabled={isPending}
+              aria-label={`${label} 감정 선택`}
+              aria-pressed={isSelected}
+              className={[
+                "group flex flex-col items-center gap-1.5 rounded-xl px-3 py-2.5",
+                "transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-50",
+                isSelected
+                  ? "bg-blue-200 ring-2 ring-blue-500 scale-105 shadow-sm"
+                  : "hover:bg-sub-gray-3 hover:scale-105 active:scale-95",
+              ].join(" ")}
+            >
+              <span
+                className={[
+                  "text-2xl leading-none transition-transform duration-200",
+                  isSelected ? "scale-110" : "group-hover:scale-110",
+                ].join(" ")}
+              >
+                {emoji}
+              </span>
+              <span
+                className={[
+                  "text-xs font-medium transition-colors",
+                  isSelected ? "text-blue-700" : "text-black-400",
+                ].join(" ")}
+              >
+                {label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ─── MypagePage ───────────────────────────────────────────────────────────────
+
 export function MypagePage(): ReactElement {
+  const queryClient = useQueryClient();
   const { data: me, isLoading } = useQuery({ queryKey: ["me"], queryFn: getMe });
   const { handleLogout } = useLogout();
+  const { data: todayEmotion } = useTodayEmotion();
+
+  const { mutate: selectEmotion, isPending } = useMutation({
+    mutationFn: postTodayEmotion,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["emotionLogs", "today"] });
+      void queryClient.invalidateQueries({ queryKey: ["emotionLogs"] });
+    },
+  });
+
+  const selectedEmotion = todayEmotion?.emotion ?? null;
 
   return (
     <main
       id="main-content"
-      className="mx-auto min-h-screen max-w-2xl px-4 py-10 tablet:px-6 desktop:max-w-3xl"
+      className="mx-auto min-h-screen w-full max-w-xl px-4 pb-24 pt-10
+        tablet:max-w-2xl tablet:px-8 tablet:pt-14
+        pc:max-w-4xl pc:px-12 pc:pt-16"
     >
-      <section className="mb-8 flex flex-col items-center gap-3">
+      <section className="mb-6 flex flex-col items-center gap-3 animate-fade-in-up">
         {isLoading || !me ? (
           <ProfileSkeleton />
         ) : (
           <>
             <ProfileImageUpload currentImageUrl={me.image} nickname={me.nickname} />
-            <p className="text-lg font-semibold text-black-700">{me.nickname}</p>
+            <p className="text-xl font-bold text-black-800">{me.nickname}</p>
+            <button
+              type="button"
+              onClick={() => void handleLogout()}
+              className="flex items-center gap-1.5 rounded-full border border-line-200 px-4 py-1.5
+                text-xs text-black-400 transition-all duration-200
+                hover:border-error/40 hover:bg-red-50 hover:text-error active:scale-95"
+            >
+              <LogOut className="h-3.5 w-3.5" aria-hidden="true" />
+              로그아웃
+            </button>
           </>
         )}
-
-        <button
-          type="button"
-          onClick={() => void handleLogout()}
-          className="mt-1 flex items-center gap-1.5 rounded-full border border-line-200 px-4 py-1.5 text-sm text-black-400 transition-colors hover:border-red-300 hover:text-red-500"
-        >
-          <LogOut className="h-4 w-4" aria-hidden="true" />
-          로그아웃
-        </button>
       </section>
 
-      {me && <MypageActivity userId={me.id} />}
+      <div className="mb-5 animate-fade-in-up" style={{ animationDelay: "80ms" }}>
+        <EmotionSelector
+          selectedEmotion={selectedEmotion}
+          onSelect={selectEmotion}
+          isPending={isPending}
+        />
+      </div>
+
+      {me && (
+        <div className="animate-fade-in-up" style={{ animationDelay: "160ms" }}>
+          <MypageActivity userId={me.id} />
+        </div>
+      )}
     </main>
   );
 }

--- a/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
@@ -7,6 +7,7 @@ import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
 
 import { useMonthlyEmotions } from "@/entities/emotion-log/api/useMonthlyEmotions";
+
 import type { Emotion } from "@/entities/emotion-log/model/schema";
 
 const EMOTION_EMOJI: Record<Emotion, string> = {
@@ -86,17 +87,18 @@ export function EmotionCalendar({ userId }: EmotionCalendarProps): React.ReactEl
   }
 
   return (
-    <section className="w-full rounded-2xl bg-white px-6 py-5">
-      <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-base font-semibold text-black-700">
-          {year}년 {month}월
+    <section className="w-full rounded-2xl bg-white px-5 py-5 shadow-sm ring-1 ring-line-200">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-black-700">
+          {year}년 {String(month).padStart(2, "0")}월
         </h2>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-0.5">
           <button
             type="button"
             aria-label="이전 달"
             onClick={handlePrevMonth}
-            className="flex h-8 w-8 items-center justify-center rounded-full text-black-300 transition-colors hover:bg-blue-200 hover:text-black-600"
+            className="flex h-8 w-8 items-center justify-center rounded-full text-black-400
+              transition-all duration-150 hover:bg-blue-200 hover:text-blue-700 active:scale-90"
           >
             <ChevronLeft className="h-4 w-4" />
           </button>
@@ -104,7 +106,8 @@ export function EmotionCalendar({ userId }: EmotionCalendarProps): React.ReactEl
             type="button"
             aria-label="다음 달"
             onClick={handleNextMonth}
-            className="flex h-8 w-8 items-center justify-center rounded-full text-black-300 transition-colors hover:bg-blue-200 hover:text-black-600"
+            className="flex h-8 w-8 items-center justify-center rounded-full text-black-400
+              transition-all duration-150 hover:bg-blue-200 hover:text-blue-700 active:scale-90"
           >
             <ChevronRight className="h-4 w-4" />
           </button>

--- a/src/widgets/mypage-activity/ui/EmotionPieChart.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionPieChart.tsx
@@ -14,10 +14,10 @@ interface EmotionMeta {
 
 // Emojis and labels aligned with EmotionSelector to ensure consistency across the UI
 const EMOTION_META: Record<Emotion, EmotionMeta> = {
-  MOVED: { label: "감동", emoji: "😍", color: "#48bb98" },
+  MOVED: { label: "감동", emoji: "🥹", color: "#48bb98" },
   HAPPY: { label: "기쁨", emoji: "😊", color: "#fbc85b" },
   WORRIED: { label: "고민", emoji: "😟", color: "#8e80e3" },
-  SAD: { label: "슬픔", emoji: "😢", color: "#5195ee" },
+  SAD: { label: "슬픔", emoji: "😔", color: "#5195ee" },
   ANGRY: { label: "분노", emoji: "😡", color: "#e46e80" },
 };
 
@@ -57,9 +57,12 @@ export function EmotionPieChart({ emotionLogs }: EmotionPieChartProps): React.Re
 
   if (chartData.length === 0) {
     return (
-      <section className="w-full rounded-2xl bg-white px-6 py-5">
-        <h2 className="mb-4 text-base font-semibold text-black-700">감정 기록</h2>
-        <p className="text-center text-sm text-black-300">이번 달 감정 기록이 없어요.</p>
+      <section className="flex w-full flex-col rounded-2xl bg-white px-5 py-5 shadow-sm ring-1 ring-line-200">
+        <h2 className="mb-4 text-sm font-semibold text-black-700">감정 기록</h2>
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 py-8">
+          <span className="text-4xl">📭</span>
+          <p className="text-sm text-black-300">이번 달 감정 기록이 없어요</p>
+        </div>
       </section>
     );
   }
@@ -67,23 +70,27 @@ export function EmotionPieChart({ emotionLogs }: EmotionPieChartProps): React.Re
   const topEmotion = chartData.reduce((max, d) => (d.count > max.count ? d : max));
 
   return (
-    <section className="w-full rounded-2xl bg-white px-6 py-5">
-      <h2 className="mb-4 text-base font-semibold text-black-700">감정 기록</h2>
+    <section className="w-full rounded-2xl bg-white px-5 py-5 shadow-sm ring-1 ring-line-200">
+      <h2 className="mb-4 text-sm font-semibold text-black-700">감정 기록</h2>
 
       <div className="flex items-center gap-6">
-        <div className="relative h-[120px] w-[120px] shrink-0">
+        {/* Donut chart */}
+        <div className="relative h-[130px] w-[130px] shrink-0">
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
                 data={chartData}
                 cx="50%"
                 cy="50%"
-                innerRadius={38}
-                outerRadius={55}
+                innerRadius={40}
+                outerRadius={58}
                 dataKey="count"
                 startAngle={90}
                 endAngle={-270}
                 strokeWidth={0}
+                isAnimationActive={true}
+                animationBegin={0}
+                animationDuration={600}
               >
                 {chartData.map(({ emotion }) => (
                   <Cell key={emotion} fill={EMOTION_META[emotion].color} />
@@ -94,21 +101,33 @@ export function EmotionPieChart({ emotionLogs }: EmotionPieChartProps): React.Re
 
           <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
             <span className="text-2xl leading-none">{EMOTION_META[topEmotion.emotion].emoji}</span>
-            <span className="mt-0.5 text-[10px] font-medium text-black-300">
-              {EMOTION_META[topEmotion.emotion].label}
+            <span className="mt-1 text-xs font-semibold text-black-500">
+              {topEmotion.percentage}%
             </span>
           </div>
         </div>
 
-        <ul className="flex flex-col gap-2">
+        {/* Legend */}
+        <ul className="flex flex-1 flex-col gap-2.5">
           {chartData.map(({ emotion, percentage }) => (
-            <li key={emotion} className="flex items-center gap-2 text-sm">
+            <li key={emotion} className="flex items-center gap-2.5">
               <span
                 className="h-2.5 w-2.5 shrink-0 rounded-full"
                 style={{ backgroundColor: EMOTION_META[emotion].color }}
               />
-              <span className="w-12 text-black-400">{EMOTION_META[emotion].label}</span>
-              <span className="font-semibold text-black-600">{percentage}%</span>
+              <span className="w-10 text-xs text-black-400">{EMOTION_META[emotion].label}</span>
+              <div className="relative flex-1 overflow-hidden rounded-full bg-line-100 h-1.5">
+                <div
+                  className="absolute left-0 top-0 h-full rounded-full transition-all duration-700"
+                  style={{
+                    width: `${percentage}%`,
+                    backgroundColor: EMOTION_META[emotion].color,
+                  }}
+                />
+              </div>
+              <span className="w-8 text-right text-xs font-semibold text-black-600">
+                {percentage}%
+              </span>
             </li>
           ))}
         </ul>

--- a/src/widgets/mypage-activity/ui/MypageActivity.tsx
+++ b/src/widgets/mypage-activity/ui/MypageActivity.tsx
@@ -7,21 +7,58 @@ import Link from "next/link";
 import { ChevronDown } from "lucide-react";
 
 import { useMyComments } from "@/entities/comment";
-import { useEpigrams } from "@/entities/epigram";
-import { useMonthlyEmotions } from "@/entities/emotion-log";
 import type { Comment } from "@/entities/comment";
+import { useMonthlyEmotions } from "@/entities/emotion-log";
+import { useEpigrams } from "@/entities/epigram";
 import type { Epigram } from "@/entities/epigram";
 
 import { EmotionCalendar } from "./EmotionCalendar";
 import { EmotionPieChart } from "./EmotionPieChart";
 
 const PAGE_SIZE = 3;
+const NOW = new Date();
 
 interface MypageActivityProps {
   userId: number;
 }
 
-// ─── Epigram section ───────────────────────────────────────────────────────
+// ─── Shared helpers ───────────────────────────────────────────────────────────
+
+interface LoadMoreButtonProps {
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+}
+
+function LoadMoreButton({
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+}: LoadMoreButtonProps): ReactElement | null {
+  if (!hasNextPage) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={onLoadMore}
+      disabled={isFetchingNextPage}
+      className="mt-4 flex w-full items-center justify-center gap-1.5 rounded-xl border
+        border-line-200 py-2.5 text-sm text-black-400 transition-all duration-200
+        hover:border-blue-400 hover:bg-blue-50 hover:text-blue-600
+        disabled:cursor-not-allowed disabled:opacity-60 active:scale-[0.98]"
+    >
+      <ChevronDown
+        className={["h-4 w-4 transition-transform", isFetchingNextPage ? "animate-spin" : ""].join(
+          " "
+        )}
+        aria-hidden="true"
+      />
+      {isFetchingNextPage ? "불러오는 중..." : "더보기"}
+    </button>
+  );
+}
+
+// ─── Epigram section ──────────────────────────────────────────────────────────
 
 interface MyEpigramItemProps {
   epigram: Epigram;
@@ -32,10 +69,14 @@ function MyEpigramItem({ epigram }: MyEpigramItemProps): ReactElement {
     <li>
       <Link
         href={`/epigrams/${epigram.id}`}
-        className="block rounded-xl border border-line-200 bg-white px-4 py-3 text-sm text-black-700 transition-colors hover:border-blue-300 hover:bg-blue-50"
+        className="group block rounded-xl border border-line-200 bg-white px-4 py-3.5
+          transition-all duration-200 hover:border-blue-400 hover:bg-blue-100/40 hover:shadow-sm
+          active:scale-[0.99]"
       >
-        <p className="line-clamp-2 font-medium leading-snug">{epigram.content}</p>
-        <p className="mt-1 text-right text-xs text-black-300">— {epigram.author}</p>
+        <p className="line-clamp-2 text-sm font-medium leading-snug text-black-700 transition-colors group-hover:text-blue-800">
+          {epigram.content}
+        </p>
+        <p className="mt-1.5 text-right text-xs text-black-300">— {epigram.author}</p>
       </Link>
     </li>
   );
@@ -52,37 +93,39 @@ function MyEpigramList({ userId }: MyEpigramListProps): ReactElement {
   });
 
   const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
+  const totalCount = data?.pages[0]?.totalCount ?? 0;
 
   return (
-    <section className="rounded-2xl bg-white px-6 py-5">
-      <h2 className="mb-4 text-base font-semibold text-black-700">내 에피그램</h2>
+    <section className="rounded-2xl bg-white px-5 py-5 shadow-sm ring-1 ring-line-200">
+      <h2 className="mb-4 flex items-center gap-2 text-sm font-semibold text-black-700">
+        내 에피그램
+        {totalCount > 0 && (
+          <span className="rounded-full bg-blue-200 px-2 py-0.5 text-xs font-semibold text-blue-700">
+            {totalCount}
+          </span>
+        )}
+      </h2>
 
       {epigrams.length === 0 ? (
-        <p className="text-center text-sm text-black-300">작성한 에피그램이 없어요.</p>
+        <p className="py-4 text-center text-sm text-black-300">작성한 에피그램이 없어요.</p>
       ) : (
-        <ul className="flex flex-col gap-3">
+        <ul className="flex flex-col gap-2.5">
           {epigrams.map((epigram) => (
             <MyEpigramItem key={epigram.id} epigram={epigram} />
           ))}
         </ul>
       )}
 
-      {hasNextPage && (
-        <button
-          type="button"
-          onClick={() => void fetchNextPage()}
-          disabled={isFetchingNextPage}
-          className="mt-4 flex w-full items-center justify-center gap-1 rounded-xl border border-line-200 py-2 text-sm text-black-400 transition-colors hover:border-blue-300 hover:text-blue-600 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          <ChevronDown className="h-4 w-4" aria-hidden="true" />
-          {isFetchingNextPage ? "불러오는 중..." : "더보기"}
-        </button>
-      )}
+      <LoadMoreButton
+        hasNextPage={hasNextPage ?? false}
+        isFetchingNextPage={isFetchingNextPage}
+        onLoadMore={() => void fetchNextPage()}
+      />
     </section>
   );
 }
 
-// ─── Comment section ────────────────────────────────────────────────────────
+// ─── Comment section ──────────────────────────────────────────────────────────
 
 interface MyCommentItemProps {
   comment: Comment;
@@ -93,9 +136,13 @@ function MyCommentItem({ comment }: MyCommentItemProps): ReactElement {
     <li>
       <Link
         href={`/epigrams/${comment.epigramId}`}
-        className="block rounded-xl border border-line-200 bg-white px-4 py-3 text-sm text-black-700 transition-colors hover:border-blue-300 hover:bg-blue-50"
+        className="group block rounded-xl border border-line-200 bg-white px-4 py-3.5
+          transition-all duration-200 hover:border-blue-400 hover:bg-blue-100/40 hover:shadow-sm
+          active:scale-[0.99]"
       >
-        <p className="line-clamp-2 leading-snug">{comment.content}</p>
+        <p className="line-clamp-2 text-sm leading-snug text-black-600 transition-colors group-hover:text-blue-800">
+          {comment.content}
+        </p>
       </Link>
     </li>
   );
@@ -115,44 +162,36 @@ function MyCommentList({ userId }: MyCommentListProps): ReactElement {
   const totalCount = data?.pages[0]?.totalCount ?? 0;
 
   return (
-    <section className="rounded-2xl bg-white px-6 py-5">
-      <h2 className="mb-4 flex items-center gap-2 text-base font-semibold text-black-700">
+    <section className="rounded-2xl bg-white px-5 py-5 shadow-sm ring-1 ring-line-200">
+      <h2 className="mb-4 flex items-center gap-2 text-sm font-semibold text-black-700">
         내 댓글
         {totalCount > 0 && (
-          <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-600">
+          <span className="rounded-full bg-blue-200 px-2 py-0.5 text-xs font-semibold text-blue-700">
             {totalCount}
           </span>
         )}
       </h2>
 
       {comments.length === 0 ? (
-        <p className="text-center text-sm text-black-300">작성한 댓글이 없어요.</p>
+        <p className="py-4 text-center text-sm text-black-300">작성한 댓글이 없어요.</p>
       ) : (
-        <ul className="flex flex-col gap-3">
+        <ul className="flex flex-col gap-2.5">
           {comments.map((comment) => (
             <MyCommentItem key={comment.id} comment={comment} />
           ))}
         </ul>
       )}
 
-      {hasNextPage && (
-        <button
-          type="button"
-          onClick={() => void fetchNextPage()}
-          disabled={isFetchingNextPage}
-          className="mt-4 flex w-full items-center justify-center gap-1 rounded-xl border border-line-200 py-2 text-sm text-black-400 transition-colors hover:border-blue-300 hover:text-blue-600 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          <ChevronDown className="h-4 w-4" aria-hidden="true" />
-          {isFetchingNextPage ? "불러오는 중..." : "더보기"}
-        </button>
-      )}
+      <LoadMoreButton
+        hasNextPage={hasNextPage ?? false}
+        isFetchingNextPage={isFetchingNextPage}
+        onLoadMore={() => void fetchNextPage()}
+      />
     </section>
   );
 }
 
-// ─── MypageActivity ─────────────────────────────────────────────────────────
-
-const NOW = new Date();
+// ─── MypageActivity ───────────────────────────────────────────────────────────
 
 export function MypageActivity({ userId }: MypageActivityProps): ReactElement {
   const { data: monthlyLogs = [] } = useMonthlyEmotions({
@@ -163,10 +202,15 @@ export function MypageActivity({ userId }: MypageActivityProps): ReactElement {
 
   return (
     <div className="flex flex-col gap-4">
-      <EmotionCalendar userId={userId} />
-      <EmotionPieChart emotionLogs={monthlyLogs} />
-      <MyEpigramList userId={userId} />
-      <MyCommentList userId={userId} />
+      <div className="grid gap-4 tablet:grid-cols-2">
+        <EmotionCalendar userId={userId} />
+        <EmotionPieChart emotionLogs={monthlyLogs} />
+      </div>
+
+      <div className="grid gap-4 pc:grid-cols-2">
+        <MyEpigramList userId={userId} />
+        <MyCommentList userId={userId} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## ✏️ 작업 내용

- **MypagePage**: 오늘의 감정 선택 카드(`EmotionSelector`) 추가 — 5개 감정 버튼, 선택 시 scale+ring 하이라이트, 오늘 날짜 표시
- **MypageActivity**: tablet+ 2열 그리드(캘린더+파이차트), PC 2열(에피그램+댓글) 반응형 레이아웃
- **EmotionCalendar**: 카드 shadow/ring 스타일, 날짜 네비 hover·active·scale 인터랙션, 요일 헤더 색상·폰트 개선
- **EmotionPieChart**: 도넛 차트 마운트 애니메이션, 진행률 바 범례, empty state 아이콘+문구 개선, 이모지 통일(🥹 😔)
- **MypageActivity**: 중복 더보기 버튼 패턴을 `LoadMoreButton` 헬퍼로 추출
- **globals.css**: 캘린더 타일 scale hover·active 전환, 요일 헤더 스타일 개선

## 🗨️ 논의 사항 (참고 사항)

- 반응형 브레이크포인트: Mobile 단일 컬럼 → Tablet 캘린더+차트 2열 → PC 에피그램+댓글 2열
- `TODAY_LABEL`을 모듈 상수로 호이스팅해 매 렌더마다 재계산되지 않도록 처리

## 기대효과

- 피그마 시안 컨셉을 유지하면서 반응형(모바일/태블릿/PC) 레이아웃 적용
- 오늘의 감정 선택 인터랙션으로 사용자 참여 유도
- 카드 shadow·hover·active 전환으로 전반적인 인터랙티브 UX 개선

Closes #191
