### PR TITLE
fix: ErrorBoundary reset에 useQueryErrorResetBoundary 추가 및 throwOnError 설정 (#201)

### DIFF
--- a/src/app/addepigram/error.tsx
+++ b/src/app/addepigram/error.tsx
@@ -3,6 +3,8 @@
 import { useEffect } from "react";
 import type { ReactElement } from "react";
 
+import { useQueryErrorResetBoundary } from "@tanstack/react-query";
+
 import { RouteErrorFallback } from "@/shared/ui/RouteErrorFallback";
 
 interface ErrorPageProps {
@@ -11,9 +13,16 @@ interface ErrorPageProps {
 }
 
 export default function ErrorPage({ error, reset }: ErrorPageProps): ReactElement {
+  const { reset: resetQueries } = useQueryErrorResetBoundary();
+
   useEffect(() => {
     console.error(error);
   }, [error]);
 
-  return <RouteErrorFallback reset={reset} />;
+  function handleReset(): void {
+    resetQueries();
+    reset();
+  }
+
+  return <RouteErrorFallback reset={handleReset} />;
 }

--- a/src/app/epigrams/[id]/error.tsx
+++ b/src/app/epigrams/[id]/error.tsx
@@ -3,6 +3,8 @@
 import { useEffect } from "react";
 import type { ReactElement } from "react";
 
+import { useQueryErrorResetBoundary } from "@tanstack/react-query";
+
 import { RouteErrorFallback } from "@/shared/ui/RouteErrorFallback";
 
 interface ErrorPageProps {
@@ -11,9 +13,16 @@ interface ErrorPageProps {
 }
 
 export default function ErrorPage({ error, reset }: ErrorPageProps): ReactElement {
+  const { reset: resetQueries } = useQueryErrorResetBoundary();
+
   useEffect(() => {
     console.error(error);
   }, [error]);
 
-  return <RouteErrorFallback reset={reset} />;
+  function handleReset(): void {
+    resetQueries();
+    reset();
+  }
+
+  return <RouteErrorFallback reset={handleReset} />;
 }

--- a/src/app/epigrams/error.tsx
+++ b/src/app/epigrams/error.tsx
@@ -3,6 +3,8 @@
 import { useEffect } from "react";
 import type { ReactElement } from "react";
 
+import { useQueryErrorResetBoundary } from "@tanstack/react-query";
+
 import { RouteErrorFallback } from "@/shared/ui/RouteErrorFallback";
 
 interface ErrorPageProps {
@@ -11,9 +13,16 @@ interface ErrorPageProps {
 }
 
 export default function ErrorPage({ error, reset }: ErrorPageProps): ReactElement {
+  const { reset: resetQueries } = useQueryErrorResetBoundary();
+
   useEffect(() => {
     console.error(error);
   }, [error]);
 
-  return <RouteErrorFallback reset={reset} />;
+  function handleReset(): void {
+    resetQueries();
+    reset();
+  }
+
+  return <RouteErrorFallback reset={handleReset} />;
 }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -3,6 +3,8 @@
 import { useEffect } from "react";
 import type { ReactElement } from "react";
 
+import { useQueryErrorResetBoundary } from "@tanstack/react-query";
+
 import { RouteErrorFallback } from "@/shared/ui/RouteErrorFallback";
 
 interface ErrorPageProps {
@@ -11,9 +13,16 @@ interface ErrorPageProps {
 }
 
 export default function ErrorPage({ error, reset }: ErrorPageProps): ReactElement {
+  const { reset: resetQueries } = useQueryErrorResetBoundary();
+
   useEffect(() => {
     console.error(error);
   }, [error]);
 
-  return <RouteErrorFallback reset={reset} />;
+  function handleReset(): void {
+    resetQueries();
+    reset();
+  }
+
+  return <RouteErrorFallback reset={handleReset} />;
 }

--- a/src/app/mypage/error.tsx
+++ b/src/app/mypage/error.tsx
@@ -3,6 +3,8 @@
 import { useEffect } from "react";
 import type { ReactElement } from "react";
 
+import { useQueryErrorResetBoundary } from "@tanstack/react-query";
+
 import { RouteErrorFallback } from "@/shared/ui/RouteErrorFallback";
 
 interface ErrorPageProps {
@@ -11,9 +13,16 @@ interface ErrorPageProps {
 }
 
 export default function ErrorPage({ error, reset }: ErrorPageProps): ReactElement {
+  const { reset: resetQueries } = useQueryErrorResetBoundary();
+
   useEffect(() => {
     console.error(error);
   }, [error]);
 
-  return <RouteErrorFallback reset={reset} />;
+  function handleReset(): void {
+    resetQueries();
+    reset();
+  }
+
+  return <RouteErrorFallback reset={handleReset} />;
 }

--- a/src/app/search/error.tsx
+++ b/src/app/search/error.tsx
@@ -3,6 +3,8 @@
 import { useEffect } from "react";
 import type { ReactElement } from "react";
 
+import { useQueryErrorResetBoundary } from "@tanstack/react-query";
+
 import { RouteErrorFallback } from "@/shared/ui/RouteErrorFallback";
 
 interface ErrorPageProps {
@@ -11,9 +13,16 @@ interface ErrorPageProps {
 }
 
 export default function ErrorPage({ error, reset }: ErrorPageProps): ReactElement {
+  const { reset: resetQueries } = useQueryErrorResetBoundary();
+
   useEffect(() => {
     console.error(error);
   }, [error]);
 
-  return <RouteErrorFallback reset={reset} />;
+  function handleReset(): void {
+    resetQueries();
+    reset();
+  }
+
+  return <RouteErrorFallback reset={handleReset} />;
 }

--- a/src/shared/api/QueryProvider.tsx
+++ b/src/shared/api/QueryProvider.tsx
@@ -18,6 +18,7 @@ export function QueryProvider({ children }: QueryProviderProps): ReactElement {
           queries: {
             staleTime: 60 * 1000,
             retry: 1,
+            throwOnError: true,
           },
         },
       })


### PR DESCRIPTION
## ✏️ 작업 내용

- `QueryProvider` defaultOptions에 `throwOnError: true` 추가 — React Query 에러가 error boundary로 전파되도록 설정
- 6개 `error.tsx` 파일에 `useQueryErrorResetBoundary()` 추가 — "다시 시도" 클릭 시 React Query 캐시 에러도 함께 초기화
- PR #200(T082)의 `ErrorBoundary.tsx`, `RouteErrorFallback.tsx`, `error.tsx` 파일들을 이 브랜치에 포함 (PR #200이 미머지 상태이므로)

## 🗨️ 논의 사항 (참고 사항)

기존 `reset()`은 React 에러 바운더리 상태만 초기화하고 React Query 캐시는 그대로 남아, 다시 시도 시 즉시 재throw 되는 문제가 있었습니다.

## 기대효과

"다시 시도" 버튼 클릭 시 React Query 캐시 에러까지 초기화되어 실제로 재요청이 발생하고 정상 복구됩니다.

Closes #201