### PR TITLE
feat: 컴포넌트 레벨 ErrorBoundary 적용 (#203)

### DIFF
--- a/src/shared/ui/SectionErrorFallback.tsx
+++ b/src/shared/ui/SectionErrorFallback.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import type { ReactElement } from "react";
+
+import { AlertTriangle } from "lucide-react";
+
+interface SectionErrorFallbackProps {
+  reset: () => void;
+}
+
+export function SectionErrorFallback({ reset }: SectionErrorFallbackProps): ReactElement {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-2xl border border-red-100 bg-red-50 py-10 text-center">
+      <AlertTriangle className="h-5 w-5 text-red-400" strokeWidth={1.5} aria-hidden="true" />
+      <p className="text-sm font-medium text-red-500">불러오지 못했습니다</p>
+      <button
+        type="button"
+        onClick={reset}
+        className="text-xs text-black-400 underline underline-offset-2 hover:text-black-600"
+      >
+        다시 시도
+      </button>
+    </div>
+  );
+}

--- a/src/views/epigram-detail/ui/EpigramDetailPage.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailPage.tsx
@@ -13,6 +13,8 @@ import { getMe } from "@/entities/user";
 import { useEpigramDelete } from "@/features/epigram-delete";
 import { LikeButton } from "@/features/epigram-like";
 import { copyToClipboard } from "@/shared/lib/clipboard";
+import { ErrorBoundary } from "@/shared/ui/ErrorBoundary";
+import { SectionErrorFallback } from "@/shared/ui/SectionErrorFallback";
 import { CommentSection } from "@/widgets/comment-section";
 
 interface EpigramDetailPageProps {
@@ -186,7 +188,9 @@ export function EpigramDetailPage({ epigramId }: EpigramDetailPageProps): ReactE
         </div>
       </div>
 
-      <CommentSection epigramId={epigramId} />
+      <ErrorBoundary fallback={(_, reset) => <SectionErrorFallback reset={reset} />}>
+        <CommentSection epigramId={epigramId} />
+      </ErrorBoundary>
     </div>
   );
 }

--- a/src/views/search/ui/SearchPage.tsx
+++ b/src/views/search/ui/SearchPage.tsx
@@ -8,6 +8,8 @@ import { useSearchEpigrams } from "@/entities/epigram";
 import { SearchBar, SearchResultItem, useSearch } from "@/features/epigram-search";
 import { useIntersectionObserver } from "@/shared/hooks/useIntersectionObserver";
 import { useScrollToTop } from "@/shared/hooks/useScrollToTop";
+import { ErrorBoundary } from "@/shared/ui/ErrorBoundary";
+import { SectionErrorFallback } from "@/shared/ui/SectionErrorFallback";
 
 const SEARCH_LIMIT = 10;
 
@@ -195,7 +197,16 @@ export function SearchPage(): ReactElement {
         />
 
         <section aria-label="검색 결과">
-          {activeKeyword ? <SearchResults keyword={activeKeyword} /> : <InitialState />}
+          {activeKeyword ? (
+            <ErrorBoundary
+              key={activeKeyword}
+              fallback={(_, reset) => <SectionErrorFallback reset={reset} />}
+            >
+              <SearchResults keyword={activeKeyword} />
+            </ErrorBoundary>
+          ) : (
+            <InitialState />
+          )}
         </section>
       </div>
 

--- a/src/widgets/epigram-feed/ui/EpigramFeed.tsx
+++ b/src/widgets/epigram-feed/ui/EpigramFeed.tsx
@@ -8,6 +8,8 @@ import Link from "next/link";
 import type { Epigram } from "@/entities/epigram";
 import { useEpigrams, useTodayEpigram } from "@/entities/epigram";
 import { EmptyState } from "@/shared/ui/EmptyState";
+import { ErrorBoundary } from "@/shared/ui/ErrorBoundary";
+import { SectionErrorFallback } from "@/shared/ui/SectionErrorFallback";
 
 const FEED_PAGE_SIZE = 5;
 
@@ -162,10 +164,14 @@ function EpigramFeedList(): ReactElement {
 export function EpigramFeed(): ReactElement {
   return (
     <div className="flex flex-col gap-10">
-      <TodayEpigramSection />
+      <ErrorBoundary fallback={(_, reset) => <SectionErrorFallback reset={reset} />}>
+        <TodayEpigramSection />
+      </ErrorBoundary>
       <section aria-label="최신 에피그램">
         <h2 className="mb-4 text-xl font-bold text-black-900">최신 에피그램</h2>
-        <EpigramFeedList />
+        <ErrorBoundary fallback={(_, reset) => <SectionErrorFallback reset={reset} />}>
+          <EpigramFeedList />
+        </ErrorBoundary>
       </section>
     </div>
   );

--- a/src/widgets/mypage-activity/ui/MypageActivity.tsx
+++ b/src/widgets/mypage-activity/ui/MypageActivity.tsx
@@ -10,6 +10,9 @@ import { useMyComments } from "@/entities/comment";
 import { useMonthlyEmotions } from "@/entities/emotion-log";
 import { useEpigrams } from "@/entities/epigram";
 
+import { ErrorBoundary } from "@/shared/ui/ErrorBoundary";
+import { SectionErrorFallback } from "@/shared/ui/SectionErrorFallback";
+
 import { EmotionCalendar } from "./EmotionCalendar";
 import { EmotionPieChart } from "./EmotionPieChart";
 
@@ -205,8 +208,12 @@ export function MypageActivity({ userId }: MypageActivityProps): ReactElement {
   return (
     <div className="flex flex-col gap-4">
       <div className="grid gap-4 tablet:grid-cols-2">
-        <EmotionCalendar userId={userId} />
-        <EmotionPieChart emotionLogs={monthlyLogs} />
+        <ErrorBoundary fallback={(_, reset) => <SectionErrorFallback reset={reset} />}>
+          <EmotionCalendar userId={userId} />
+        </ErrorBoundary>
+        <ErrorBoundary fallback={(_, reset) => <SectionErrorFallback reset={reset} />}>
+          <EmotionPieChart emotionLogs={monthlyLogs} />
+        </ErrorBoundary>
       </div>
 
       <div className="grid gap-4 pc:grid-cols-2">


### PR DESCRIPTION
## ✏️ 작업 내용

- `src/shared/ui/SectionErrorFallback.tsx` — 섹션 단위 compact 에러 fallback 컴포넌트 추가
- `MypageActivity` — `EmotionCalendar`, `EmotionPieChart` 각각 `ErrorBoundary`로 래핑 (react-calendar, recharts 서드파티 렌더 에러 격리)
- `EpigramFeed` — `TodayEpigramSection`, `EpigramFeedList` 각각 `ErrorBoundary`로 래핑 (섹션 독립 에러 처리)
- `EpigramDetailPage` — `CommentSection`을 `ErrorBoundary`로 래핑 (댓글 실패 시 본문/좋아요 유지)
- `SearchPage` — `SearchResults`를 `ErrorBoundary`로 래핑, `key={activeKeyword}` 적용으로 검색어 변경 시 에러 상태 자동 초기화

## 🗨️ 논의 사항 (참고 사항)

`SearchPage`의 `ErrorBoundary`에 `key={activeKeyword}`를 추가하여 검색어가 바뀌면 에러 상태가 자동으로 리셋되도록 처리.

## 기대효과

각 섹션이 독립적으로 에러를 처리하여, 한 섹션이 실패해도 나머지 페이지 기능은 정상 동작합니다.

Closes #203