### PR TITLE
chore: 전체 UI/UX 디자인 개선 — Header·Landing·Detail·Search·Comment (#207)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -92,6 +92,8 @@
   --animate-fade-in-up: fadeInUp 0.55s ease-out both;
   --animate-fade-in: fadeIn 0.4s ease-out both;
   --animate-float: float 4s ease-in-out infinite;
+  --animate-slide-up: slideUp 0.35s cubic-bezier(0.16, 1, 0.3, 1) both;
+  --animate-scale-in: scaleIn 0.25s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
 @keyframes fadeInUp {
@@ -124,9 +126,37 @@
   }
 }
 
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes scaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 body {
   background-color: var(--color-background);
   color: var(--color-black-600);
+  scrollbar-gutter: stable;
+}
+
+::selection {
+  background-color: var(--color-blue-300);
+  color: var(--color-blue-950);
 }
 
 /* =====================

--- a/src/views/epigram-detail/ui/EpigramDetailPage.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailPage.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import { useQuery } from "@tanstack/react-query";
-import { ExternalLink, MoreVertical, Share2 } from "lucide-react";
+import { ArrowLeft, ExternalLink, MoreVertical, Share2 } from "lucide-react";
 
 import { useEpigramDetail } from "@/entities/epigram";
 import { getMe } from "@/entities/user";
@@ -90,6 +90,7 @@ function SkeletonLoader(): ReactElement {
 
 export function EpigramDetailPage({ epigramId }: EpigramDetailPageProps): ReactElement {
   const [isCopied, setIsCopied] = useState(false);
+  const router = useRouter();
 
   const { data: epigram, isLoading: isEpigramLoading } = useEpigramDetail(epigramId);
   const { data: me, isLoading: isMeLoading } = useQuery({ queryKey: ["me"], queryFn: getMe });
@@ -117,9 +118,15 @@ export function EpigramDetailPage({ epigramId }: EpigramDetailPageProps): ReactE
   return (
     <div className="mx-auto w-full max-w-2xl px-4 py-10 tablet:max-w-3xl tablet:px-6 pc:max-w-screen-xl pc:px-16 pc:py-16 desktop:max-w-screen-2xl desktop:px-24">
       <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-black-950 tablet:text-3xl pc:text-4xl desktop:text-5xl">
-          에피그램
-        </h1>
+        <button
+          type="button"
+          onClick={() => router.back()}
+          aria-label="뒤로 가기"
+          className="flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-sm font-medium text-black-400 transition-colors duration-150 hover:bg-blue-50 hover:text-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        >
+          <ArrowLeft size={16} aria-hidden="true" />
+          돌아가기
+        </button>
         <div className="flex items-center gap-2">
           <div className="relative">
             <button
@@ -141,11 +148,13 @@ export function EpigramDetailPage({ epigramId }: EpigramDetailPageProps): ReactE
       </div>
 
       <div className="mb-8 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-blue-200 tablet:p-8 pc:p-10">
-        <blockquote className="mb-6 text-lg leading-relaxed text-black-800 tablet:text-xl pc:text-2xl desktop:text-3xl">
+        <blockquote className="mb-6 font-serif text-lg leading-relaxed text-black-800 tablet:text-xl pc:text-2xl desktop:text-3xl">
           {epigram.content}
         </blockquote>
 
-        <p className="mb-4 text-right text-sm font-medium text-black-500">— {epigram.author}</p>
+        <p className="mb-4 text-right font-serif text-sm font-medium text-black-400">
+          — {epigram.author}
+        </p>
 
         {epigram.referenceTitle && (
           <div className="mb-4 flex items-center justify-end gap-1.5">

--- a/src/views/landing/ui/LandingPage.tsx
+++ b/src/views/landing/ui/LandingPage.tsx
@@ -34,7 +34,7 @@ function HeroSection(): ReactElement {
         {"\u201C"}
       </span>
 
-      <div className="relative flex flex-col items-center gap-6 animate-fade-in-up">
+      <div className="relative flex flex-col items-center gap-8 animate-fade-in-up">
         <div className="flex flex-col gap-3">
           <h1 className="font-serif text-2xl font-normal leading-tight text-black-500 tablet:text-4xl desktop:text-5xl">
             나만 갖고 있기엔
@@ -45,17 +45,20 @@ function HeroSection(): ReactElement {
             다른 사람들과 감정을 공유해 보세요.
           </p>
         </div>
+        {/* border + fill-on-hover premium CTA */}
         <Link
           href="/epigrams"
-          className="inline-flex h-12 w-32 items-center justify-center rounded-xl bg-black-500 text-base font-semibold text-white shadow-sm transition-all duration-200 hover:bg-black-600 hover:shadow-md active:scale-95"
+          className="inline-flex h-12 w-36 items-center justify-center rounded-xl border border-blue-950 bg-blue-950 text-sm font-semibold text-white shadow-sm transition-all duration-300 hover:bg-transparent hover:text-blue-950 hover:shadow-md active:scale-95"
         >
           시작하기
         </Link>
       </div>
 
       <div className="absolute bottom-8 flex flex-col items-center gap-1">
-        <span className="text-xs font-semibold text-blue-400">더 알아보기</span>
-        <ChevronDown size={24} className="animate-bounce text-blue-400" aria-hidden="true" />
+        <span className="text-xs font-semibold tracking-[0.2em] text-blue-400 uppercase">
+          scroll
+        </span>
+        <ChevronDown size={20} className="animate-bounce text-blue-400" aria-hidden="true" />
       </div>
     </section>
   );
@@ -63,22 +66,34 @@ function HeroSection(): ReactElement {
 
 function EmotionSection(): ReactElement {
   return (
-    <section className="flex flex-col items-center gap-10 px-6 py-16 tablet:px-[72px] desktop:px-[120px]">
-      <div className="w-full max-w-sm rounded-2xl bg-blue-200 px-6 py-8">
-        <div className="mb-6 flex flex-wrap gap-3">
+    <section className="flex flex-col items-center gap-10 bg-blue-200 px-6 py-20 tablet:px-[72px] desktop:px-[120px]">
+      <div className="flex flex-col items-center gap-2 text-center">
+        <span className="font-serif text-xs uppercase tracking-[0.2em] text-blue-500">
+          감정을 담다
+        </span>
+        <h2 className="font-serif text-2xl font-normal text-blue-950 tablet:text-3xl">
+          오늘의 감정에 맞는 에피그램
+        </h2>
+      </div>
+
+      <div className="w-full max-w-md rounded-2xl bg-white/60 px-8 py-8 shadow-sm backdrop-blur-sm">
+        <div className="mb-6 flex flex-wrap gap-2">
           {EMOTION_TAGS.map((tag) => (
-            <span key={tag} className="font-serif text-xl text-blue-400">
+            <span
+              key={tag}
+              className="rounded-full border border-blue-300/60 px-3 py-1 font-serif text-sm text-blue-700"
+            >
               {tag}
             </span>
           ))}
         </div>
-        <div className="flex justify-center gap-2">
+        <div className="flex justify-center gap-3">
           {EMOTION_BADGES.map(({ emoji, label }) => (
             <div key={label} className="flex flex-col items-center gap-2">
-              <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-400 text-2xl transition-transform duration-200 hover:-translate-y-1">
+              <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-blue-200 text-2xl shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-md">
                 {emoji}
               </div>
-              <span className="text-xs font-semibold text-gray-400">{label}</span>
+              <span className="text-xs font-medium text-blue-600">{label}</span>
             </div>
           ))}
         </div>
@@ -89,12 +104,17 @@ function EmotionSection(): ReactElement {
 
 function EpigramsSection(): ReactElement {
   return (
-    <section className="mx-auto w-full max-w-5xl flex flex-col gap-10 px-6 py-16 tablet:px-[72px]">
-      <h2 className="text-2xl font-bold text-black-950 tablet:text-3xl">
-        사용자들이 직접
-        <br />
-        인용한 에피그램들
-      </h2>
+    <section className="mx-auto w-full max-w-5xl flex flex-col gap-10 px-6 py-20 tablet:px-[72px]">
+      <div className="flex flex-col gap-1">
+        <span className="font-serif text-xs uppercase tracking-[0.2em] text-blue-400">
+          community
+        </span>
+        <h2 className="font-serif text-2xl font-normal text-black-800 tablet:text-3xl">
+          사용자들이 직접
+          <br />
+          인용한 에피그램들
+        </h2>
+      </div>
       <ul className="flex flex-col gap-4">
         {SAMPLE_EPIGRAMS.map((item, index) => (
           <li
@@ -102,9 +122,9 @@ function EpigramsSection(): ReactElement {
             className="animate-fade-in-up"
             style={{ animationDelay: `${index * 0.12}s` }}
           >
-            <div className="flex flex-col gap-1 rounded-2xl border-l-2 border-blue-500 bg-white px-6 py-6 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md">
+            <div className="flex flex-col gap-1 rounded-2xl border-l-[3px] border-blue-400 bg-white px-6 py-6 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-blue-600 hover:shadow-md">
               <p className="font-serif text-sm leading-relaxed text-black-600">{item.content}</p>
-              <p className="font-serif text-sm text-blue-400">{item.author}</p>
+              <p className="mt-2 font-serif text-sm text-blue-400">{item.author}</p>
             </div>
             <div className="mt-2 flex gap-2 px-2">
               {item.tags.map((tag) => (
@@ -122,19 +142,33 @@ function EpigramsSection(): ReactElement {
 
 function CtaSection(): ReactElement {
   return (
-    <section className="flex flex-col items-center gap-8 bg-blue-950 px-6 py-20 tablet:px-[72px] desktop:px-[120px]">
-      <div className="flex flex-col items-center gap-2">
-        <span className="font-serif text-xs uppercase tracking-widest text-blue-500">
+    <section className="relative flex flex-col items-center gap-8 overflow-hidden bg-blue-950 px-6 py-24 tablet:px-[72px] desktop:px-[120px]">
+      {/* 미묘한 radial glow */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(ellipse 60% 50% at 50% 60%, rgba(107,130,169,0.18) 0%, transparent 70%)",
+        }}
+        aria-hidden="true"
+      />
+
+      <div className="relative flex flex-col items-center gap-2">
+        <span className="font-serif text-xs uppercase tracking-[0.25em] text-blue-500">
           every day
         </span>
         <div className="flex flex-col items-center leading-snug">
-          <span className="font-serif text-3xl font-bold text-white">날마다</span>
+          <span className="font-serif text-3xl font-light text-white">날마다</span>
           <span className="font-serif text-3xl font-bold text-blue-300">에피그램</span>
         </div>
+        <p className="mt-2 font-serif text-sm text-blue-600">
+          좋은 글귀 하나가 하루를 바꿀 수 있습니다
+        </p>
       </div>
+
       <Link
         href="/epigrams"
-        className="inline-flex h-12 w-32 items-center justify-center rounded-xl border border-blue-400 text-base font-semibold text-white transition-all duration-200 hover:bg-white hover:text-blue-950 active:scale-95"
+        className="relative inline-flex h-12 w-36 items-center justify-center rounded-xl border border-blue-400/60 text-sm font-semibold text-white transition-all duration-300 hover:border-white hover:bg-white/10 active:scale-95"
       >
         시작하기
       </Link>

--- a/src/views/search/ui/SearchPage.tsx
+++ b/src/views/search/ui/SearchPage.tsx
@@ -65,8 +65,21 @@ function SearchNoResults({ keyword }: SearchNoResultsProps): ReactElement {
 
 function InitialState(): ReactElement {
   return (
-    <div className="flex flex-col items-center gap-2 py-24 text-center pc:py-36">
-      <p className="text-sm text-black-300 pc:text-base">검색어를 입력해 에피그램을 찾아보세요</p>
+    <div className="flex flex-col items-center gap-4 py-24 text-center pc:py-36">
+      <span
+        className="select-none font-serif text-[72px] leading-none text-blue-200 pc:text-[96px]"
+        aria-hidden="true"
+      >
+        {"\u201C"}
+      </span>
+      <div className="flex flex-col gap-1.5">
+        <p className="font-serif text-base text-black-500 pc:text-lg">
+          검색어를 입력해 에피그램을 찾아보세요
+        </p>
+        <p className="text-xs text-black-300 pc:text-sm">
+          작가 이름, 글귀, 태그 모두 검색 가능합니다
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/widgets/comment-section/ui/CommentSection.tsx
+++ b/src/widgets/comment-section/ui/CommentSection.tsx
@@ -58,7 +58,7 @@ function CommentItem({ comment, epigramId, currentUserId }: CommentItemProps): R
   }
 
   return (
-    <li className="flex gap-3 rounded-2xl border border-line-200 bg-white px-5 py-4 shadow-sm transition-all duration-200 hover:border-blue-200 hover:shadow-md">
+    <li className="flex gap-3 rounded-xl bg-sub-gray-3 px-4 py-4 transition-colors duration-200 hover:bg-blue-200/30">
       <button
         type="button"
         onClick={handleProfileClick}
@@ -129,7 +129,7 @@ function CommentItem({ comment, epigramId, currentUserId }: CommentItemProps): R
 
 function CommentSkeleton(): ReactElement {
   return (
-    <li className="flex gap-3 rounded-2xl border border-line-200 bg-white px-5 py-4">
+    <li className="flex gap-3 rounded-xl bg-sub-gray-3 px-4 py-4">
       <div className="h-9 w-9 flex-shrink-0 animate-pulse rounded-full bg-blue-200" />
       <div className="flex-1 space-y-2">
         <div className="h-3 w-24 animate-pulse rounded bg-blue-200" />

--- a/src/widgets/epigram-card/ui/EpigramCard.tsx
+++ b/src/widgets/epigram-card/ui/EpigramCard.tsx
@@ -34,7 +34,7 @@ function EpigramTagList({ tags }: EpigramTagListProps): ReactElement | null {
     <ul className="mt-4 flex flex-wrap gap-2" aria-label="태그 목록">
       {tags.map((tag) => (
         <li key={tag.id}>
-          <span className="rounded-full bg-blue-200 px-3 py-1 text-xs font-medium text-blue-700 transition-colors duration-150 hover:bg-blue-300">
+          <span className="rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-medium text-blue-600 transition-all duration-150 hover:border-blue-400 hover:bg-blue-100 hover:text-blue-800">
             #{tag.name}
           </span>
         </li>
@@ -45,11 +45,11 @@ function EpigramTagList({ tags }: EpigramTagListProps): ReactElement | null {
 
 export function EpigramCard({ epigram, isFeatured = false }: EpigramCardProps): ReactElement {
   const baseClasses =
-    "group block rounded-2xl border bg-white px-6 py-6 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2";
+    "group block rounded-2xl border-l-[3px] bg-white pl-6 pr-6 py-6 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2";
 
   const featuredClasses = isFeatured
-    ? "border-blue-300 shadow-sm shadow-blue-100 hover:border-blue-400 hover:shadow-blue-200"
-    : "border-line-200 shadow-sm hover:border-blue-300";
+    ? "border-blue-500 shadow-blue-100 hover:border-blue-700"
+    : "border-blue-300 hover:border-blue-500";
 
   return (
     <Link href={`/epigrams/${epigram.id}`} className={`${baseClasses} ${featuredClasses}`}>

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -1,7 +1,16 @@
+"use client";
+
 import type { ReactElement } from "react";
 
-import { Menu, User } from "lucide-react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { Menu, User } from "lucide-react";
+
+const NAV_LINKS = [
+  { href: "/epigrams", label: "피드" },
+  { href: "/search", label: "검색" },
+] as const;
 
 interface LogoProps {
   size: "sm" | "lg";
@@ -12,10 +21,38 @@ function Logo({ size }: LogoProps): ReactElement {
   return (
     <Link href="/" className="flex items-center gap-1" aria-label="홈으로 이동">
       <span
-        className={`font-black leading-[26px] text-black-600 whitespace-nowrap ${isLg ? "text-[20px]" : "text-[16px]"}`}
+        className={`font-serif font-black leading-[26px] tracking-tight text-blue-950 whitespace-nowrap ${isLg ? "text-[20px]" : "text-[16px]"}`}
       >
         Epigram
       </span>
+    </Link>
+  );
+}
+
+interface NavLinkProps {
+  href: string;
+  label: string;
+  textSize: "sm" | "md";
+}
+
+function NavLink({ href, label, textSize }: NavLinkProps): ReactElement {
+  const pathname = usePathname();
+  const isActive = pathname.startsWith(href);
+  const isMd = textSize === "md";
+
+  return (
+    <Link
+      href={href}
+      className={[
+        "relative font-semibold transition-colors duration-150",
+        isMd ? "text-[16px] leading-[26px]" : "text-[14px] leading-6",
+        isActive ? "text-blue-700" : "text-black-600 hover:text-blue-700",
+      ].join(" ")}
+    >
+      {label}
+      {isActive && (
+        <span className="absolute -bottom-1 left-0 h-0.5 w-full rounded-full bg-blue-500" />
+      )}
     </Link>
   );
 }
@@ -42,7 +79,7 @@ function UserSection({ iconSize, textSize }: UserSectionProps): ReactElement {
 
 export function Header(): ReactElement {
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-line-100 bg-white">
+    <header className="sticky top-0 z-50 w-full border-b border-line-100 bg-white/90 backdrop-blur-md">
       {/* Mobile (base ~ 743px): 햄버거 + 로고 / 유저 */}
       <div className="flex h-[52px] items-center justify-between px-6 tablet:hidden">
         <div className="flex items-center gap-3">
@@ -54,36 +91,27 @@ export function Header(): ReactElement {
         <UserSection iconSize="sm" textSize="sm" />
       </div>
 
-      {/* Tablet (744px ~ 1919px): 로고 + 텍스트 링크 / 유저 */}
-      <div className="hidden h-[60px] items-center justify-between px-[72px] tablet:flex desktop:hidden">
+      {/* Tablet (744px ~ 1279px): 로고 + 텍스트 링크 / 유저 */}
+      <div className="hidden h-[60px] items-center justify-between px-[72px] tablet:flex pc:hidden">
         <div className="flex items-center gap-6">
           <Logo size="sm" />
           <nav className="flex gap-6" aria-label="주요 메뉴">
-            <Link href="/feed" className="text-[14px] font-semibold leading-6 text-black-600">
-              피드
-            </Link>
-            <Link href="/search" className="text-[14px] font-semibold leading-6 text-black-600">
-              검색
-            </Link>
+            {NAV_LINKS.map((link) => (
+              <NavLink key={link.href} href={link.href} label={link.label} textSize="sm" />
+            ))}
           </nav>
         </div>
         <UserSection iconSize="sm" textSize="sm" />
       </div>
 
-      {/* Desktop (1920px+): 로고 + 텍스트 링크 / 유저 */}
-      <div className="hidden h-[80px] items-center justify-between px-[120px] desktop:flex">
+      {/* Desktop (1280px+): 로고 + 텍스트 링크 / 유저 */}
+      <div className="hidden h-[80px] items-center justify-between px-[120px] pc:flex">
         <div className="flex items-center gap-9">
           <Logo size="lg" />
           <nav className="flex gap-6" aria-label="주요 메뉴">
-            <Link href="/feed" className="text-[16px] font-semibold leading-[26px] text-black-600">
-              피드
-            </Link>
-            <Link
-              href="/search"
-              className="text-[16px] font-semibold leading-[26px] text-black-600"
-            >
-              검색
-            </Link>
+            {NAV_LINKS.map((link) => (
+              <NavLink key={link.href} href={link.href} label={link.label} textSize="md" />
+            ))}
           </nav>
         </div>
         <UserSection iconSize="lg" textSize="md" />


### PR DESCRIPTION
## ✏️ 작업 내용

- **globals.css**: `slideUp`/`scaleIn` 키프레임 추가, `scrollbar-gutter: stable` 레이아웃 시프트 방지, `::selection` 브랜드 컬러 적용
- **Header**: `bg-white/90 backdrop-blur-md`로 스크롤 시 콘텐츠 구분, 로고 `font-serif` 브랜드 일관성, 현재 경로 기반 nav 링크 active 밑줄 표시
- **LandingPage**: Hero CTA 버튼 `border + fill-on-hover` premium feel, EmotionSection을 `bg-blue-200` 전체 섹션으로 분리, CtaSection radial glow 오버레이 추가, EpigramsSection 헤딩 serif 정돈
- **EpigramCard**: `border-l-[3px]` accent 강화, 태그 pill `border + bg-blue-50` 스타일로 개선
- **EpigramDetailPage**: 의미 없는 `h1 "에피그램"` → 뒤로가기 버튼으로 교체, 인용 `blockquote`에 `font-serif` 적용
- **SearchPage**: `InitialState` 텍스트 한 줄 → 장식 인용부호 + 서브 안내 문구로 개선
- **CommentSection**: 댓글 카드 `border/shadow` 제거 → `bg-sub-gray-3` subtle 배경으로 경량화

## 🗨️ 논의 사항 (참고 사항)

기존 blue 컬러 컨셉과 serif/sans 폰트 조합을 유지하면서 UX 완성도를 높이는 방향으로 작업했습니다. 기능 변경 없이 스타일만 개선했습니다.

## 기대효과

- 헤더가 스크롤 시 콘텐츠와 시각적으로 명확히 구분되어 가독성 향상
- 랜딩 페이지 섹션 간 리듬감이 생겨 전체적인 완성도 향상
- EpigramCard의 left border accent로 인용문 성격이 더 명확하게 전달
- 에피그램 상세 페이지에서 의미 없는 h1 제거로 UX 흐름 개선
- 댓글 카드 경량화로 콘텐츠 집중도 향상

Closes #207