### PR TITLE
fix: API 버그 2건 수정 — useTodayEmotion userId 누락, useEpigramEdit null 전송 (#209)

### DIFF
--- a/src/entities/emotion-log/api/useTodayEmotion.ts
+++ b/src/entities/emotion-log/api/useTodayEmotion.ts
@@ -4,11 +4,14 @@ import { apiClient } from "@/shared/api/client";
 
 import type { EmotionLog } from "../model/schema";
 
-export function useTodayEmotion(): UseQueryResult<EmotionLog | null, Error> {
+export function useTodayEmotion(userId: number): UseQueryResult<EmotionLog | null, Error> {
   return useQuery({
-    queryKey: ["emotionLogs", "today"],
+    queryKey: ["emotionLogs", "today", userId],
+    enabled: userId > 0,
     queryFn: async () => {
-      const response = await apiClient.get<EmotionLog | null>("/api/emotionLogs/today");
+      const response = await apiClient.get<EmotionLog | null>("/api/emotionLogs/today", {
+        params: { userId },
+      });
       return response.data;
     },
   });

--- a/src/features/emotion-select/model/useEmotionSelect.ts
+++ b/src/features/emotion-select/model/useEmotionSelect.ts
@@ -1,7 +1,8 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type { Emotion } from "@/entities/emotion-log";
 import { postTodayEmotion, useTodayEmotion } from "@/entities/emotion-log";
+import { getMe } from "@/entities/user";
 
 interface UseEmotionSelectReturn {
   hasSelectedToday: boolean;
@@ -11,7 +12,8 @@ interface UseEmotionSelectReturn {
 
 export function useEmotionSelect(): UseEmotionSelectReturn {
   const queryClient = useQueryClient();
-  const { data: todayEmotion } = useTodayEmotion();
+  const { data: me } = useQuery({ queryKey: ["me"], queryFn: getMe });
+  const { data: todayEmotion } = useTodayEmotion(me?.id ?? 0);
 
   const { mutate, isPending } = useMutation({
     mutationFn: postTodayEmotion,

--- a/src/features/epigram-edit/model/useEpigramEdit.ts
+++ b/src/features/epigram-edit/model/useEpigramEdit.ts
@@ -13,8 +13,8 @@ import type { Epigram } from "@/entities/epigram";
 interface UpdateEpigramBody {
   content?: string;
   author?: string;
-  referenceTitle?: string | null;
-  referenceUrl?: string | null;
+  referenceTitle?: string;
+  referenceUrl?: string;
   tags?: string[];
 }
 
@@ -61,8 +61,8 @@ export function useEpigramEdit(epigramId: number): UseEpigramEditReturn {
     mutate({
       content: values.content,
       author: resolveAuthor(values),
-      referenceTitle: values.referenceTitle?.trim() || null,
-      referenceUrl: values.referenceUrl?.trim() || null,
+      referenceTitle: values.referenceTitle?.trim() || undefined,
+      referenceUrl: values.referenceUrl?.trim() || undefined,
       tags: values.tags,
     });
   }

--- a/src/views/mypage/ui/MypagePage.tsx
+++ b/src/views/mypage/ui/MypagePage.tsx
@@ -107,7 +107,7 @@ export function MypagePage(): ReactElement {
   const queryClient = useQueryClient();
   const { data: me, isLoading } = useQuery({ queryKey: ["me"], queryFn: getMe });
   const { handleLogout } = useLogout();
-  const { data: todayEmotion } = useTodayEmotion();
+  const { data: todayEmotion } = useTodayEmotion(me?.id ?? 0);
 
   const { mutate: selectEmotion, isPending } = useMutation({
     mutationFn: postTodayEmotion,


### PR DESCRIPTION
## ✏️ 작업 내용

Swagger 대조 검증 결과 발견된 API 호출 버그 2건 수정

**① `useTodayEmotion` — 필수 `userId` query param 누락**
- `useTodayEmotion(userId: number)` 파라미터 추가, `enabled: userId > 0`으로 me 로드 대기
- `MypagePage`: `useTodayEmotion(me?.id ?? 0)` 으로 호출
- `useEmotionSelect`: `getMe`로 userId 확보 후 전달

**② `useEpigramEdit` — nullable=False 필드에 `null` 전송**
- Swagger `PATCH /epigrams/{id}` 스펙: `referenceTitle`, `referenceUrl` 모두 `nullable=False`
- `null` → `undefined` 변경으로 빈 값일 때 필드 omit 처리

## 🗨️ 논의 사항 (참고 사항)

- `useEmotionSelect`(피드 페이지 감정 선택 위젯)도 `useTodayEmotion`을 사용하고 있었음. 내부에서 `useQuery`로 `me`를 가져와 userId 전달하도록 수정

## 기대효과

- 마이페이지 오늘의 감정 조회 정상 동작
- 피드 페이지 감정 선택 완료 여부 판단 정상 동작
- 에피그램 수정 시 참조 필드 삭제 동작 정상화

Closes #209