### PR TITLE
feat: /feeds 라우트 및 FeedsPage stub 생성 (#213)

### DIFF
--- a/src/app/feeds/page.tsx
+++ b/src/app/feeds/page.tsx
@@ -1,0 +1,7 @@
+import type { ReactElement } from "react";
+
+import { FeedsPage } from "@/views/feeds";
+
+export default function FeedsRoute(): ReactElement {
+  return <FeedsPage />;
+}

--- a/src/views/feeds/index.ts
+++ b/src/views/feeds/index.ts
@@ -1,0 +1,1 @@
+export { FeedsPage } from "./ui/FeedsPage";

--- a/src/views/feeds/ui/FeedsPage.tsx
+++ b/src/views/feeds/ui/FeedsPage.tsx
@@ -1,0 +1,5 @@
+import type { ReactElement } from "react";
+
+export function FeedsPage(): ReactElement {
+  return <div />;
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- `src/app/feeds/page.tsx` 생성 — `/feeds` 라우트 파일 (FeedsPage 렌더링)
- `src/views/feeds/ui/FeedsPage.tsx` stub 생성 — T086에서 실제 구현 예정
- `src/views/feeds/index.ts` 퍼블릭 API 정의

## 🗨️ 논의 사항 (참고 사항)

FeedsPage는 현재 빌드 통과용 stub. 실제 UI(2컬럼 그리드 + 무한스크롤)는 T086(#214)에서 구현.

## 기대효과

`/feeds` 경로로 접근 가능한 라우트 확보

Closes #213