### PR TITLE
feat: FeedsPage 뷰 구현 — 2컬럼 그리드 + 무한스크롤 (#215)

### DIFF
--- a/src/views/feeds/ui/FeedsPage.tsx
+++ b/src/views/feeds/ui/FeedsPage.tsx
@@ -1,5 +1,124 @@
+"use client";
+
 import type { ReactElement } from "react";
 
+import { BookOpenText, ChevronDown, ChevronUp, Plus } from "lucide-react";
+import Link from "next/link";
+
+import { useEpigrams } from "@/entities/epigram";
+import { useScrollToTop } from "@/shared/hooks/useScrollToTop";
+import { EmptyState } from "@/shared/ui/EmptyState";
+import { ErrorBoundary } from "@/shared/ui/ErrorBoundary";
+import { SectionErrorFallback } from "@/shared/ui/SectionErrorFallback";
+import { EpigramCard } from "@/widgets/epigram-card";
+
+const FEEDS_PAGE_SIZE = 10;
+
+function FeedsGrid(): ReactElement {
+  const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useEpigrams({
+    limit: FEEDS_PAGE_SIZE,
+  });
+
+  const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 gap-4 tablet:grid-cols-2">
+        {Array.from({ length: FEEDS_PAGE_SIZE }).map((_, i) => (
+          <div key={i} className="h-40 animate-pulse rounded-2xl bg-blue-100" />
+        ))}
+      </div>
+    );
+  }
+
+  if (epigrams.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-line-200">
+        <EmptyState
+          icon={
+            <BookOpenText className="h-7 w-7 text-blue-400" strokeWidth={1.5} aria-hidden="true" />
+          }
+          title="등록된 에피그램이 없습니다"
+          description="첫 번째 에피그램을 작성해 보세요."
+          action={
+            <Link
+              href="/addepigram"
+              className="inline-flex h-9 items-center justify-center rounded-xl border border-black-400 px-5 text-xs font-semibold text-black-500 transition-all duration-200 hover:bg-black-500 hover:text-white active:scale-95"
+            >
+              에피그램 만들기
+            </Link>
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <ul className="grid grid-cols-1 gap-4 tablet:grid-cols-2">
+        {epigrams.map((epigram) => (
+          <li key={epigram.id}>
+            <EpigramCard epigram={epigram} />
+          </li>
+        ))}
+      </ul>
+      {hasNextPage && (
+        <div className="flex justify-center">
+          <button
+            type="button"
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+            className="group flex items-center gap-2 rounded-full border border-line-200 bg-white px-6 py-2.5 text-sm font-medium text-black-400 shadow-sm transition-all duration-200 hover:border-blue-400 hover:text-blue-700 hover:shadow-md active:scale-95 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isFetchingNextPage ? (
+              <span
+                className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+                aria-hidden="true"
+              />
+            ) : (
+              <ChevronDown
+                className="h-4 w-4 transition-transform duration-200 group-hover:translate-y-0.5"
+                aria-hidden="true"
+              />
+            )}
+            {isFetchingNextPage ? "불러오는 중..." : "+ 에피그램 더보기"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function FeedsPage(): ReactElement {
-  return <div />;
+  const { isVisible, scrollToTop } = useScrollToTop();
+
+  return (
+    <main className="mx-auto w-full max-w-5xl px-6 py-10 tablet:px-[72px] desktop:px-[120px]">
+      <div className="mb-8 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-black-900">피드</h1>
+        <Link
+          href="/addepigram"
+          className="flex items-center gap-1.5 rounded-xl bg-blue-950 px-4 py-2 text-sm font-semibold text-white transition-all duration-200 hover:bg-blue-800 active:scale-95"
+        >
+          <Plus size={16} aria-hidden="true" />
+          에피그램 만들기
+        </Link>
+      </div>
+
+      <ErrorBoundary fallback={(_, reset) => <SectionErrorFallback reset={reset} />}>
+        <FeedsGrid />
+      </ErrorBoundary>
+
+      {isVisible && (
+        <button
+          type="button"
+          onClick={scrollToTop}
+          aria-label="맨 위로 이동"
+          className="fixed bottom-8 right-6 flex h-11 w-11 items-center justify-center rounded-full bg-blue-950 text-white shadow-lg transition-all duration-200 hover:bg-blue-800 active:scale-95 tablet:right-[72px]"
+        >
+          <ChevronUp size={20} aria-hidden="true" />
+        </button>
+      )}
+    </main>
+  );
 }


### PR DESCRIPTION
## ✏️ 작업 내용

- `FeedsPage` 뷰 구현 (기존 stub 대체)
- "피드" 제목 + "에피그램 만들기" 버튼 헤더
- `useEpigrams` + `useInfiniteQuery` 기반 2컬럼 에피그램 그리드
- "+ 에피그램 더보기" 수동 로드 버튼 (로딩 스피너 포함)
- `useScrollToTop`으로 스크롤 위 버튼 구현
- 로딩 스켈레톤 (10개 pulse), 빈 상태 EmptyState 처리
- `ErrorBoundary` + `SectionErrorFallback` 적용

## 🗨️ 논의 사항 (참고 사항)

- `LoadMoreButton`, `ScrollToTopButton` 패턴이 SearchPage·EpigramFeed와 유사 — 공통 컴포넌트 추출은 별도 리팩토링 이슈로 분리 예정
- `fetchNextPage`를 `onClick`에 직접 전달하면 `MouseEvent` 타입 충돌 발생 — 래핑 함수 유지

## 기대효과

`/feeds`에서 에피그램 목록을 2컬럼 그리드 + 무한스크롤로 확인 가능

Closes #215