### PR TITLE
chore: 미들웨어 /feeds 공개 접근 주석 명확화 및 tasks.md 완료 체크 (#217)

### DIFF
--- a/specs/001-epigram-core-pages/tasks.md
+++ b/specs/001-epigram-core-pages/tasks.md
@@ -246,6 +246,21 @@
 
 ---
 
+## Phase 10: /feeds 피드 페이지 (에피그램 목록 무한 스크롤)
+
+**목적**: 에피그램 전체 목록을 2컬럼 그리드 + 무한 스크롤로 표시하는 전용 피드 페이지 구현
+
+**독립 테스트**: `/feeds` 진입 → 에피그램 2컬럼 그리드 표시 → 스크롤 시 추가 로드 → "에피그램 더보기" 버튼 동작 확인
+
+- [x] T084 [P] Header nav "피드" 링크를 `/feeds`로 변경 (`src/widgets/header/ui/Header.tsx`)
+- [x] T085 [P] `/feeds` 라우트 파일 생성 (`src/app/feeds/page.tsx`)
+- [x] T086 [P] feeds 뷰 구현 — "피드" 제목, 2컬럼 에피그램 카드 그리드, `useInfiniteQuery` 무한 스크롤, "에피그램 더보기" 버튼(수동 로드 트리거), 스크롤 위 버튼 (`src/views/feeds/ui/FeedsPage.tsx`, `src/views/feeds/index.ts`)
+- [x] T087 `/feeds` 미들웨어 비인증 접근 허용 확인 — 공개 페이지이므로 미들웨어 보호 경로에서 제외 (`src/middleware.ts`)
+
+**체크포인트**: 랜딩 "시작하기" → `/epigrams` 이동 확인 | nav "피드" → `/feeds` 이동 확인 | 무한 스크롤 추가 로드 정상 동작 확인
+
+---
+
 ## 의존성 및 실행 순서
 
 ### Phase 의존 관계

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 // /epigrams/[id], /epigrams/[id]/edit 등 하위 경로는 보호
-// /epigrams 자체(목록)와 /search는 비회원 접근 가능
+// /epigrams 자체(목록), /feeds, /search는 비회원 접근 가능
 function isProtectedPath(pathname: string): boolean {
   if (pathname.startsWith("/epigrams/")) return true;
   if (pathname.startsWith("/addepigram")) return true;


### PR DESCRIPTION
## ✏️ 작업 내용

- `src/middleware.ts` 주석에 `/feeds`도 비회원 접근 가능 경로임을 명시
- `specs/001-epigram-core-pages/tasks.md` Phase 10 T084~T087 완료 체크박스 업데이트

## 🗨️ 논의 사항 (참고 사항)

코드 수정 불필요 확인:
- `isProtectedPath`에 `/feeds` 없음 → 보호 대상 아님
- `config.matcher`에 `/feeds` 없음 → 미들웨어 실행 자체가 안 됨
- 주석 명확화로 이후 유지보수 시 혼란 방지

## 기대효과

`/feeds` 비인증 공개 접근 허용 명시적으로 문서화

Closes #217