### PR TITLE
feat: EmotionSelector 항상 표시 + 비로그인 알림 + 선택 감정 하이라이팅 (#221)

### DIFF
--- a/src/features/emotion-select/model/useEmotionSelect.ts
+++ b/src/features/emotion-select/model/useEmotionSelect.ts
@@ -5,15 +5,20 @@ import { postTodayEmotion, useTodayEmotion } from "@/entities/emotion-log";
 import { getMe } from "@/entities/user";
 
 interface UseEmotionSelectReturn {
-  hasSelectedToday: boolean;
+  isLoggedIn: boolean;
+  todayEmotion: Emotion | null;
   isSubmitting: boolean;
   selectEmotion: (emotion: Emotion) => void;
 }
 
 export function useEmotionSelect(): UseEmotionSelectReturn {
   const queryClient = useQueryClient();
-  const { data: me } = useQuery({ queryKey: ["me"], queryFn: getMe });
-  const { data: todayEmotion } = useTodayEmotion(me?.id ?? 0);
+  const { data: me, isSuccess: isMeLoaded } = useQuery({
+    queryKey: ["me"],
+    queryFn: getMe,
+  });
+
+  const { data: todayEmotionLog } = useTodayEmotion(me?.id ?? 0);
 
   const { mutate, isPending } = useMutation({
     mutationFn: postTodayEmotion,
@@ -23,7 +28,8 @@ export function useEmotionSelect(): UseEmotionSelectReturn {
   });
 
   return {
-    hasSelectedToday: todayEmotion != null,
+    isLoggedIn: isMeLoaded && me != null,
+    todayEmotion: todayEmotionLog?.emotion ?? null,
     isSubmitting: isPending,
     selectEmotion: mutate,
   };

--- a/src/features/emotion-select/ui/EmotionSelector.tsx
+++ b/src/features/emotion-select/ui/EmotionSelector.tsx
@@ -2,6 +2,8 @@
 
 import type { ReactElement } from "react";
 
+import { useRouter } from "next/navigation";
+
 import type { Emotion } from "@/entities/emotion-log";
 
 import { useEmotionSelect } from "../model/useEmotionSelect";
@@ -13,6 +15,7 @@ interface EmotionOption {
   hoverColor: string;
   activeColor: string;
   ringColor: string;
+  selectedColor: string;
 }
 
 const EMOTION_OPTIONS: EmotionOption[] = [
@@ -23,6 +26,7 @@ const EMOTION_OPTIONS: EmotionOption[] = [
     hoverColor: "hover:bg-red-50",
     activeColor: "active:bg-red-100",
     ringColor: "focus-visible:ring-red-300",
+    selectedColor: "bg-red-100 ring-2 ring-red-300",
   },
   {
     value: "HAPPY",
@@ -31,6 +35,7 @@ const EMOTION_OPTIONS: EmotionOption[] = [
     hoverColor: "hover:bg-yellow-50",
     activeColor: "active:bg-yellow-100",
     ringColor: "focus-visible:ring-yellow-300",
+    selectedColor: "bg-yellow-100 ring-2 ring-yellow-300",
   },
   {
     value: "WORRIED",
@@ -39,6 +44,7 @@ const EMOTION_OPTIONS: EmotionOption[] = [
     hoverColor: "hover:bg-blue-50",
     activeColor: "active:bg-blue-100",
     ringColor: "focus-visible:ring-blue-300",
+    selectedColor: "bg-blue-100 ring-2 ring-blue-300",
   },
   {
     value: "SAD",
@@ -47,6 +53,7 @@ const EMOTION_OPTIONS: EmotionOption[] = [
     hoverColor: "hover:bg-indigo-50",
     activeColor: "active:bg-indigo-100",
     ringColor: "focus-visible:ring-indigo-300",
+    selectedColor: "bg-indigo-100 ring-2 ring-indigo-300",
   },
   {
     value: "ANGRY",
@@ -55,13 +62,25 @@ const EMOTION_OPTIONS: EmotionOption[] = [
     hoverColor: "hover:bg-orange-50",
     activeColor: "active:bg-orange-100",
     ringColor: "focus-visible:ring-orange-300",
+    selectedColor: "bg-orange-100 ring-2 ring-orange-300",
   },
 ];
 
-export function EmotionSelector(): ReactElement | null {
-  const { hasSelectedToday, isSubmitting, selectEmotion } = useEmotionSelect();
+export function EmotionSelector(): ReactElement {
+  const router = useRouter();
+  const { isLoggedIn, todayEmotion, isSubmitting, selectEmotion } = useEmotionSelect();
 
-  if (hasSelectedToday) return null;
+  function handleEmotionClick(emotion: Emotion): void {
+    if (!isLoggedIn) {
+      alert("로그인이 필요합니다. 로그인 페이지로 이동합니다.");
+      router.push("/login");
+      return;
+    }
+
+    if (todayEmotion != null) return;
+
+    selectEmotion(emotion);
+  }
 
   return (
     <section className="rounded-2xl border border-line-200 bg-white px-6 py-8 shadow-sm">
@@ -69,34 +88,44 @@ export function EmotionSelector(): ReactElement | null {
         오늘의 감정은 어떤가요?
       </h2>
       <ul className="flex items-center justify-center gap-2 tablet:gap-8" role="list">
-        {EMOTION_OPTIONS.map((option) => (
-          <li key={option.value}>
-            <button
-              type="button"
-              onClick={() => selectEmotion(option.value)}
-              disabled={isSubmitting}
-              aria-label={option.label}
-              className={`
-                group flex flex-col items-center gap-1.5
-                rounded-xl p-1.5 tablet:p-2 transition-all duration-200
-                focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2
-                disabled:cursor-not-allowed disabled:opacity-50
-                ${option.hoverColor} ${option.activeColor} ${option.ringColor}
-              `}
-            >
-              <span
-                className="text-3xl tablet:text-4xl transition-transform duration-200 group-hover:scale-125 group-active:scale-110"
-                role="img"
-                aria-hidden="true"
+        {EMOTION_OPTIONS.map((option) => {
+          const isSelected = todayEmotion === option.value;
+          // 비로그인: 버튼 활성(클릭 시 로그인 유도) / 로그인: 이미 선택했으면 선택된 것 제외 비활성
+          const isButtonDisabled =
+            isLoggedIn && (isSubmitting || (todayEmotion != null && !isSelected));
+
+          return (
+            <li key={option.value}>
+              <button
+                type="button"
+                onClick={() => handleEmotionClick(option.value)}
+                disabled={isButtonDisabled}
+                aria-label={option.label}
+                aria-pressed={isSelected}
+                className={`
+                  group flex flex-col items-center gap-1.5
+                  rounded-xl p-1.5 tablet:p-2 transition-all duration-200
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2
+                  disabled:cursor-not-allowed disabled:opacity-50
+                  ${isSelected ? option.selectedColor : `${option.hoverColor} ${option.activeColor} ${option.ringColor}`}
+                `}
               >
-                {option.emoji}
-              </span>
-              <span className="text-xs font-medium text-black-300 transition-colors duration-200 group-hover:text-black-600">
-                {option.label}
-              </span>
-            </button>
-          </li>
-        ))}
+                <span
+                  className={`text-3xl tablet:text-4xl transition-transform duration-200 ${isSelected ? "scale-125" : "group-hover:scale-125 group-active:scale-110"}`}
+                  role="img"
+                  aria-hidden="true"
+                >
+                  {option.emoji}
+                </span>
+                <span
+                  className={`text-xs font-medium transition-colors duration-200 ${isSelected ? "text-black-700 font-semibold" : "text-black-300 group-hover:text-black-600"}`}
+                >
+                  {option.label}
+                </span>
+              </button>
+            </li>
+          );
+        })}
       </ul>
     </section>
   );


### PR DESCRIPTION
## Summary

- `EmotionSelector`를 항상 렌더링 (감정 선택 여부와 무관하게 표시)
- 비로그인 상태에서 클릭 시 알림 표시 후 `/login` 리다이렉트
- 오늘 이미 선택한 감정 버튼에 하이라이팅 스타일 적용 (배경색 + ring)
- `useEmotionSelect` 훅에서 `todayEmotion: Emotion | null`과 `isLoggedIn: boolean` 반환하도록 변경

## Changes

**`useEmotionSelect.ts`**
- `hasSelectedToday: boolean` → `todayEmotion: Emotion | null` + `isLoggedIn: boolean` 반환
- `retry: false` 제거 — `["me"]` 쿼리키를 6곳에서 공유하므로 retry 설정 불일치 방지

**`EmotionSelector.tsx`**
- `if (hasSelectedToday) return null` 제거 → 항상 렌더링
- `handleEmotionClick`: 비로그인 시 alert + router.push("/login"), 이미 선택 시 early return
- `disabled` 조건: 비로그인 사용자는 버튼 활성(클릭 시 로그인 유도), 로그인 후 제출 중이거나 다른 감정 선택 시 비활성

## Test plan

- [ ] 비로그인 상태에서 `/epigrams` 접근 → EmotionSelector 표시 확인
- [ ] 비로그인 상태에서 감정 클릭 → 알림 후 `/login` 이동 확인
- [ ] 로그인 후 감정 선택 → 선택한 감정 하이라이팅, 다른 감정 버튼 비활성 확인
- [ ] 이미 선택한 날 재방문 → 선택된 감정 하이라이팅 표시 확인

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)