### PR TITLE
fix: EmotionSelector 비로그인 시 getMe 에러 크래시 방지 (#223)

### DIFF
--- a/src/features/emotion-select/model/useEmotionSelect.ts
+++ b/src/features/emotion-select/model/useEmotionSelect.ts
@@ -13,9 +13,11 @@ interface UseEmotionSelectReturn {
 
 export function useEmotionSelect(): UseEmotionSelectReturn {
   const queryClient = useQueryClient();
+  // 공개 페이지에서도 로그인 상태를 확인하므로 401 실패는 에러가 아닌 "비로그인"으로 처리
   const { data: me, isSuccess: isMeLoaded } = useQuery({
     queryKey: ["me"],
     queryFn: getMe,
+    throwOnError: false,
   });
 
   const { data: todayEmotionLog } = useTodayEmotion(me?.id ?? 0);


### PR DESCRIPTION
## Summary

- 비로그인 상태에서 `/epigrams` 접근 시 `EmotionSelector`가 크래시되는 버그 수정

## 원인

`QueryProvider`의 전역 설정 `throwOnError: true`로 인해, `EmotionSelector`가 로그인 상태 확인을 위해 호출한 `getMe()`가 401로 실패하면 에러가 ErrorBoundary로 전파되어 컴포넌트 크래시 발생.

비로그인 상태에서 `getMe()` 401 실패는 에러가 아닌 유효한 "비로그인" 상태임.

## 변경 사항

`useEmotionSelect.ts`의 `["me"]` 쿼리에 `throwOnError: false` 추가

## Test plan

- [ ] 비로그인 상태에서 `/epigrams` 접근 → EmotionSelector 정상 렌더링 (에러 없음)
- [ ] 로그인 상태에서 기존 동작 동일하게 유지 확인

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)