### PR TITLE
feat: 로그인 페이지에 게스트 로그인 버튼 추가

### DIFF
--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,4 +1,5 @@
 export { AuthLeftPanel } from "./ui/AuthLeftPanel";
+export { GuestLoginButton } from "./ui/GuestLoginButton";
 export { LoginForm } from "./ui/LoginForm";
 export { SignUpForm } from "./ui/SignUpForm";
 export { useLogout } from "./api/logout";

--- a/src/features/auth/ui/GuestLoginButton.tsx
+++ b/src/features/auth/ui/GuestLoginButton.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { type ReactElement, useState } from "react";
+
+import { useRouter } from "next/navigation";
+
+import { signIn } from "@/entities/user";
+import { Button } from "@/shared/ui/Button";
+
+const GUEST_CREDENTIALS = {
+  email: "guestid@guestid.com",
+  password: "qqqqqqqq",
+} as const;
+
+export function GuestLoginButton(): ReactElement {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleGuestLogin(): Promise<void> {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await signIn(GUEST_CREDENTIALS);
+      router.push("/epigrams");
+    } catch {
+      setError("게스트 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Button
+        type="button"
+        variant="secondary"
+        isLoading={isLoading}
+        onClick={handleGuestLogin}
+        className="h-11 w-full"
+      >
+        게스트로 둘러보기
+      </Button>
+      {error !== null && <p className="text-xs text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/src/views/login/ui/LoginPage.tsx
+++ b/src/views/login/ui/LoginPage.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { AuthLeftPanel } from "@/features/auth/ui/AuthLeftPanel";
+import { GuestLoginButton } from "@/features/auth/ui/GuestLoginButton";
 import { LoginForm } from "@/features/auth/ui/LoginForm";
 import { EpigramLogo } from "@/shared/ui/EpigramLogo";
 
@@ -28,6 +29,7 @@ export async function LoginPage(): Promise<ReactElement> {
           <div className="flex flex-col gap-[50px]">
             <div className="flex flex-col gap-[10px]">
               <LoginForm />
+              <GuestLoginButton />
               <div className="flex items-center gap-2">
                 <span className="text-sm text-blue-400">회원이 아니신가요?</span>
                 <Link href="/signup" className="text-sm font-medium text-black-600 hover:underline">


### PR DESCRIPTION
## 개요

로그인 페이지에 고정 게스트 계정으로 즉시 로그인할 수 있는 버튼을 추가합니다.

## 변경 사항

- `src/features/auth/ui/GuestLoginButton.tsx` 신규 생성
  - 게스트 계정(`guestid@guestid.com`)으로 `signIn` 호출 후 `/epigrams` 리다이렉트
  - 로딩 상태(`isLoading`) 처리 — 중복 클릭 방지
  - 실패 시 인라인 에러 메시지 표시 (`alert()` 미사용)
- `LoginPage.tsx` — `LoginForm` 아래, "회원이 아니신가요?" 위에 `GuestLoginButton` 배치
- `features/auth/index.ts` — `GuestLoginButton` export 추가

## 체크리스트

- [x] 빌드 에러 없음 (`npm run build`)
- [x] 린트 에러 0개 (`npm run lint`)
- [x] 로딩 중 버튼 비활성화 처리
- [x] 에러 시 인라인 메시지 표시

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)