### PR TITLE
fix: useTodayEmotion 빈 응답 body ZodError 수정

### DIFF
--- a/src/entities/emotion-log/api/useTodayEmotion.ts
+++ b/src/entities/emotion-log/api/useTodayEmotion.ts
@@ -12,7 +12,7 @@ export function useTodayEmotion(userId: number): UseQueryResult<EmotionLog | nul
       const response = await apiClient.get<unknown>("/api/emotionLogs/today", {
         params: { userId },
       });
-      if (response.data == null) return null;
+      if (response.data == null || typeof response.data !== "object") return null;
       return emotionLogSchema.parse(response.data);
     },
   });


### PR DESCRIPTION
## 버그

`GET /emotionLogs/today` 응답이 빈 body일 때 ZodError 발생.

```
ZodError: Expected object, received string
```

## 원인

백엔드가 오늘 감정 로그가 없을 때 빈 body를 반환하는 경우, axios가 이를 `""`(빈 문자열)로 파싱함.  
기존 `response.data == null` 체크는 `null`/`undefined`만 잡아 `""` 는 통과 → `emotionLogSchema.parse("")` → 타입 에러.

## 수정

```diff
- if (response.data == null) return null;
+ if (response.data == null || typeof response.data !== "object") return null;
```

object가 아닌 모든 값(빈 문자열, 숫자, 문자열 등)을 null로 처리해 Zod 파싱 전에 안전하게 가드.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)