### PR TITLE
fix: 오늘의 에피그램 없을 때 빈 상태 문구로 대체

### DIFF
--- a/src/entities/epigram/api/useTodayEpigram.ts
+++ b/src/entities/epigram/api/useTodayEpigram.ts
@@ -9,7 +9,7 @@ export function useTodayEpigram(): UseQueryResult<EpigramDetail | null, Error> {
     queryKey: ["epigrams", "today"],
     queryFn: async () => {
       const response = await apiClient.get<unknown>("/api/epigrams/today");
-      if (response.data == null) return null;
+      if (response.data == null || typeof response.data !== "object") return null;
       return epigramDetailSchema.parse(response.data);
     },
   });

--- a/src/widgets/epigram-feed/ui/EpigramFeed.tsx
+++ b/src/widgets/epigram-feed/ui/EpigramFeed.tsx
@@ -55,6 +55,35 @@ function FeedEpigramCard({ epigram }: FeedEpigramCardProps): ReactElement {
   );
 }
 
+function TodayEpigramEmpty(): ReactElement {
+  return (
+    <div className="relative overflow-hidden rounded-2xl border border-line-200 bg-white px-8 py-10 shadow-sm">
+      {/* 장식용 여는 따옴표 */}
+      <span
+        className="pointer-events-none absolute -top-4 left-4 select-none font-serif text-[96px] leading-none text-blue-100"
+        aria-hidden="true"
+      >
+        {"\u201C"}
+      </span>
+
+      <div className="relative flex flex-col items-center gap-3 text-center">
+        <p className="font-serif text-base leading-relaxed text-black-400">
+          오늘의 에피그램이 아직 작성되지 않았습니다
+        </p>
+        <p className="font-serif text-xs text-blue-300">— 좋은 글귀가 곧 채워질 거예요</p>
+      </div>
+
+      {/* 장식용 닫는 따옴표 */}
+      <span
+        className="pointer-events-none absolute -bottom-6 right-4 select-none font-serif text-[96px] leading-none text-blue-100"
+        aria-hidden="true"
+      >
+        {"\u201D"}
+      </span>
+    </div>
+  );
+}
+
 function TodayEpigramSection(): ReactElement {
   const { data: todayEpigram, isLoading } = useTodayEpigram();
 
@@ -71,18 +100,7 @@ function TodayEpigramSection(): ReactElement {
     return (
       <section aria-label="오늘의 에피그램">
         <h2 className="mb-4 text-xl font-bold text-black-900">오늘의 에피그램</h2>
-        <div className="rounded-2xl border border-dashed border-line-200">
-          <EmptyState
-            icon={
-              <BookOpenText
-                className="h-7 w-7 text-blue-400"
-                strokeWidth={1.5}
-                aria-hidden="true"
-              />
-            }
-            title="오늘의 에피그램이 아직 없습니다"
-          />
-        </div>
+        <TodayEpigramEmpty />
       </section>
     );
   }


### PR DESCRIPTION
## 버그

오늘의 에피그램이 없을 때 "불러오지 못했습니다 / 다시 시도" 에러 UI가 표시됨.

## 원인

`useTodayEpigram`에서 백엔드 빈 body → axios가 `""` 파싱 → ZodError → ErrorBoundary가 에러 fallback 노출.

## 수정

### 1. `useTodayEpigram.ts` — null 가드 강화
```diff
- if (response.data == null) return null;
+ if (response.data == null || typeof response.data !== "object") return null;
```

### 2. `EpigramFeed.tsx` — `TodayEpigramEmpty` 컴포넌트 추가
- 에러 UI 대신 장식 따옴표(`"`, `"`) + 서체 감성의 빈 상태 카드 표시
- "오늘의 에피그램이 아직 작성되지 않았습니다" 문구
- 기존 카드 스타일(rounded-2xl, border, bg-white, shadow-sm)과 일관성 유지

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)