### PR TITLE
feat: 마이페이지 오늘의 감정/캘린더/감정 차트 UI 스타일 개선 (#246)

### DIFF
--- a/src/views/mypage/ui/MypagePage.tsx
+++ b/src/views/mypage/ui/MypagePage.tsx
@@ -22,11 +22,8 @@ const EMOTION_OPTIONS: { value: Emotion; icon: string; label: string }[] = [
 ];
 
 // Computed once at module load — date does not change during a session
-const TODAY_LABEL = new Date().toLocaleDateString("ko-KR", {
-  year: "numeric",
-  month: "2-digit",
-  day: "2-digit",
-});
+const _today = new Date();
+const TODAY_LABEL = `${_today.getFullYear()}.${String(_today.getMonth() + 1).padStart(2, "0")}.${String(_today.getDate()).padStart(2, "0")}`;
 
 // ─── Skeletons ────────────────────────────────────────────────────────────────
 
@@ -54,13 +51,13 @@ function EmotionSelector({
   isPending,
 }: EmotionSelectorProps): ReactElement {
   return (
-    <div className="w-full rounded-2xl bg-white px-5 py-5 shadow-sm ring-1 ring-line-200">
-      <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-black-600">오늘의 감정</h2>
-        <span className="text-xs text-black-300">{TODAY_LABEL}</span>
+    <div className="w-full rounded-2xl bg-white px-6 py-6 shadow-sm ring-1 ring-blue-200">
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="text-xl font-semibold text-black-600">오늘의 감정</h2>
+        <span className="text-base text-blue-400">{TODAY_LABEL}</span>
       </div>
 
-      <div className="flex items-center justify-around gap-1">
+      <div className="flex items-start justify-around gap-2">
         {EMOTION_OPTIONS.map(({ value, icon, label }) => {
           const isSelected = selectedEmotion === value;
           return (
@@ -71,12 +68,15 @@ function EmotionSelector({
               disabled={isPending}
               aria-label={`${label} 감정 선택`}
               aria-pressed={isSelected}
-              className="group flex flex-col items-center gap-1.5 rounded-xl px-3 py-2.5 transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-50 hover:bg-sub-gray-3 hover:scale-105 active:scale-95"
+              className="group flex flex-col items-center gap-2 transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-50 active:scale-95"
             >
               <span
                 className={[
-                  "flex h-12 w-12 items-center justify-center rounded-2xl transition-all duration-200",
-                  isSelected ? "ring-2 ring-illust-green" : "bg-gray-100 group-hover:bg-gray-200",
+                  "flex h-16 w-16 items-center justify-center rounded-2xl transition-all duration-200",
+                  "tablet:h-20 tablet:w-20 pc:h-24 pc:w-24",
+                  isSelected
+                    ? "border-4 border-illust-green"
+                    : "bg-blue-400/15 group-hover:bg-blue-400/25",
                 ].join(" ")}
               >
                 <Image
@@ -84,13 +84,13 @@ function EmotionSelector({
                   alt={label}
                   width={48}
                   height={48}
-                  className="h-9 w-9 transition-transform duration-200 group-hover:scale-110"
+                  className="h-9 w-9 transition-transform duration-200 group-hover:scale-110 tablet:h-10 tablet:w-10 pc:h-12 pc:w-12"
                 />
               </span>
               <span
                 className={[
-                  "text-xs transition-colors",
-                  isSelected ? "font-semibold text-illust-green" : "font-medium text-black-400",
+                  "text-sm font-semibold transition-colors tablet:text-base pc:text-lg",
+                  isSelected ? "text-black-600" : "text-gray-300",
                 ].join(" ")}
               >
                 {label}

--- a/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
@@ -2,35 +2,96 @@
 
 import { useMemo, useState, type ReactElement } from "react";
 
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import Calendar from "react-calendar";
-import "react-calendar/dist/Calendar.css";
+import Image from "next/image";
+
+import { ChevronLeft, ChevronRight, ChevronDown } from "lucide-react";
 
 import { useMonthlyEmotions } from "@/entities/emotion-log";
 
 import type { Emotion } from "@/entities/emotion-log";
 
-const EMOTION_EMOJI: Record<Emotion, string> = {
-  MOVED: "🥹",
-  HAPPY: "😊",
-  WORRIED: "😟",
-  SAD: "😔",
-  ANGRY: "😡",
+const EMOTION_ICONS: Record<Emotion, string> = {
+  MOVED: "/icon/012-heart face.png",
+  HAPPY: "/icon/035-smiling face.png",
+  WORRIED: "/icon/044-thinking.png",
+  SAD: "/icon/034-sad.png",
+  ANGRY: "/icon/Frame 65.png",
 };
 
+const EMOTION_LABELS: Record<Emotion, string> = {
+  MOVED: "감동",
+  HAPPY: "기쁨",
+  WORRIED: "고민",
+  SAD: "슬픔",
+  ANGRY: "분노",
+};
+
+const EMOTION_ORDER: Emotion[] = ["MOVED", "HAPPY", "WORRIED", "SAD", "ANGRY"];
 const WEEKDAY_LABELS = ["일", "월", "화", "수", "목", "금", "토"];
 
-// Stable reference date — does not change during a session
 const TODAY = new Date();
-const TODAY_DATE_KEY = TODAY.toLocaleDateString("sv");
+const TODAY_YEAR = TODAY.getFullYear();
+const TODAY_MONTH = TODAY.getMonth() + 1;
+const TODAY_DATE = TODAY.getDate();
+
+interface CalendarCell {
+  day: number;
+  isCurrentMonth: boolean;
+  dateKey: string;
+}
+
+function buildCalendarCells(year: number, month: number): CalendarCell[] {
+  const firstDayOfWeek = new Date(year, month - 1, 1).getDay();
+  const daysInMonth = new Date(year, month, 0).getDate();
+  const daysInPrevMonth = new Date(year, month - 1, 0).getDate();
+
+  const cells: CalendarCell[] = [];
+
+  for (let i = firstDayOfWeek - 1; i >= 0; i--) {
+    const day = daysInPrevMonth - i;
+    const prevMonth = month === 1 ? 12 : month - 1;
+    const prevYear = month === 1 ? year - 1 : year;
+    cells.push({
+      day,
+      isCurrentMonth: false,
+      dateKey: `${prevYear}-${String(prevMonth).padStart(2, "0")}-${String(day).padStart(2, "0")}`,
+    });
+  }
+
+  for (let d = 1; d <= daysInMonth; d++) {
+    cells.push({
+      day: d,
+      isCurrentMonth: true,
+      dateKey: `${year}-${String(month).padStart(2, "0")}-${String(d).padStart(2, "0")}`,
+    });
+  }
+
+  const remainder = cells.length % 7;
+  if (remainder !== 0) {
+    const nextMonth = month === 12 ? 1 : month + 1;
+    const nextYear = month === 12 ? year + 1 : year;
+    const toAdd = 7 - remainder;
+    for (let i = 1; i <= toAdd; i++) {
+      cells.push({
+        day: i,
+        isCurrentMonth: false,
+        dateKey: `${nextYear}-${String(nextMonth).padStart(2, "0")}-${String(i).padStart(2, "0")}`,
+      });
+    }
+  }
+
+  return cells;
+}
 
 interface EmotionCalendarProps {
   userId: number;
 }
 
 export function EmotionCalendar({ userId }: EmotionCalendarProps): ReactElement {
-  const [year, setYear] = useState(TODAY.getFullYear());
-  const [month, setMonth] = useState(TODAY.getMonth() + 1);
+  const [year, setYear] = useState(TODAY_YEAR);
+  const [month, setMonth] = useState(TODAY_MONTH);
+  const [filterEmotion, setFilterEmotion] = useState<Emotion | null>(null);
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
 
   const { data: emotionLogs = [] } = useMonthlyEmotions({ userId, year, month });
 
@@ -38,7 +99,6 @@ export function EmotionCalendar({ userId }: EmotionCalendarProps): ReactElement 
     () =>
       new Map<string, Emotion>(
         emotionLogs.map((log) => {
-          // "sv" locale produces ISO date strings (YYYY-MM-DD)
           const dateKey = new Date(log.createdAt).toLocaleDateString("sv");
           return [dateKey, log.emotion];
         })
@@ -46,7 +106,7 @@ export function EmotionCalendar({ userId }: EmotionCalendarProps): ReactElement 
     [emotionLogs]
   );
 
-  const activeStartDate = new Date(year, month - 1, 1);
+  const cells = useMemo(() => buildCalendarCells(year, month), [year, month]);
 
   function handlePrevMonth(): void {
     if (month === 1) {
@@ -66,65 +126,163 @@ export function EmotionCalendar({ userId }: EmotionCalendarProps): ReactElement 
     }
   }
 
-  function renderTileContent({ date, view }: { date: Date; view: string }): ReactElement | null {
-    if (view !== "month") return null;
+  function handleFilterSelect(emotion: Emotion | null): void {
+    setFilterEmotion(emotion);
+    setIsFilterOpen(false);
+  }
 
-    const dateKey = date.toLocaleDateString("sv");
-    const emotion = emotionByDate.get(dateKey);
-    if (!emotion) return null;
-
+  function isToday(cell: CalendarCell): boolean {
     return (
-      <span className="absolute inset-0 flex items-center justify-center text-lg leading-none">
-        {EMOTION_EMOJI[emotion]}
-      </span>
+      cell.isCurrentMonth && year === TODAY_YEAR && month === TODAY_MONTH && cell.day === TODAY_DATE
     );
   }
 
+  function getVisibleEmotion(cell: CalendarCell): Emotion | undefined {
+    const emotion = emotionByDate.get(cell.dateKey);
+    if (!emotion) return undefined;
+    if (filterEmotion && emotion !== filterEmotion) return undefined;
+    return emotion;
+  }
+
+  const filterLabel = filterEmotion ? EMOTION_LABELS[filterEmotion] : "없음";
+
   return (
-    <section className="w-full rounded-2xl bg-white px-5 py-5 shadow-sm ring-1 ring-line-200">
-      <div className="mb-3 flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-black-700">
-          {year}년 {String(month).padStart(2, "0")}월
-        </h2>
-        <div className="flex items-center gap-0.5">
+    <section className="w-full rounded-2xl bg-white px-6 py-6 shadow-sm ring-1 ring-blue-200">
+      {/* Header */}
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <h2 className="text-xl font-semibold text-black-600">
+            {year}년 {month}월
+          </h2>
+
+          {/* Filter dropdown */}
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setIsFilterOpen((v) => !v)}
+              className="flex items-center gap-1 rounded-xl bg-background px-3 py-1.5 text-sm font-semibold text-gray-200 transition hover:bg-blue-200"
+            >
+              필터: {filterLabel}
+              <ChevronDown className="h-4 w-4" />
+            </button>
+
+            {isFilterOpen && (
+              <ul className="absolute left-0 top-full z-10 mt-1 min-w-[110px] rounded-xl border border-blue-200 bg-white py-1 shadow-md">
+                <li>
+                  <button
+                    type="button"
+                    onClick={() => handleFilterSelect(null)}
+                    className={[
+                      "w-full px-4 py-2 text-left text-sm hover:bg-background",
+                      filterEmotion === null ? "font-semibold text-illust-green" : "text-black-500",
+                    ].join(" ")}
+                  >
+                    없음
+                  </button>
+                </li>
+                {EMOTION_ORDER.map((emotion) => (
+                  <li key={emotion}>
+                    <button
+                      type="button"
+                      onClick={() => handleFilterSelect(emotion)}
+                      className={[
+                        "flex w-full items-center gap-2 px-4 py-2 text-left text-sm hover:bg-background",
+                        filterEmotion === emotion
+                          ? "font-semibold text-illust-green"
+                          : "text-black-500",
+                      ].join(" ")}
+                    >
+                      <Image
+                        src={EMOTION_ICONS[emotion]}
+                        alt={EMOTION_LABELS[emotion]}
+                        width={20}
+                        height={20}
+                        className="h-5 w-5"
+                      />
+                      {EMOTION_LABELS[emotion]}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        {/* Navigation */}
+        <div className="flex items-center gap-3">
           <button
             type="button"
             aria-label="이전 달"
             onClick={handlePrevMonth}
-            className="flex h-8 w-8 items-center justify-center rounded-full text-black-400 transition-all duration-150 hover:bg-blue-200 hover:text-blue-700 active:scale-90"
+            className="flex h-9 w-9 items-center justify-center rounded-full transition hover:bg-background active:scale-90"
           >
-            <ChevronLeft className="h-4 w-4" />
+            <ChevronLeft className="h-5 w-5 text-black-600" strokeWidth={2.5} />
           </button>
           <button
             type="button"
             aria-label="다음 달"
             onClick={handleNextMonth}
-            className="flex h-8 w-8 items-center justify-center rounded-full text-black-400 transition-all duration-150 hover:bg-blue-200 hover:text-blue-700 active:scale-90"
+            className="flex h-9 w-9 items-center justify-center rounded-full transition hover:bg-background active:scale-90"
           >
-            <ChevronRight className="h-4 w-4" />
+            <ChevronRight className="h-5 w-5 text-black-600" strokeWidth={2.5} />
           </button>
         </div>
       </div>
 
-      <Calendar
-        activeStartDate={activeStartDate}
-        showNavigation={false}
-        view="month"
-        maxDetail="month"
-        minDetail="month"
-        calendarType="gregory"
-        locale="ko-KR"
-        formatShortWeekday={(_, date) => WEEKDAY_LABELS[date.getDay()]}
-        formatDay={(_, date) => String(date.getDate())}
-        tileContent={renderTileContent}
-        tileClassName={({ date, view }) => {
-          if (view !== "month") return null;
-          return date.toLocaleDateString("sv") === TODAY_DATE_KEY
-            ? "react-calendar__tile--today-custom"
-            : null;
-        }}
-        className="emotion-calendar w-full border-none"
-      />
+      {/* Calendar grid */}
+      <div className="grid grid-cols-7 border-l border-t border-blue-200">
+        {/* Weekday header */}
+        {WEEKDAY_LABELS.map((label) => (
+          <div
+            key={label}
+            className="flex items-center justify-center border-b border-r border-blue-200 py-3"
+          >
+            <span className="text-sm font-semibold text-gray-200 tablet:text-base">{label}</span>
+          </div>
+        ))}
+
+        {/* Day cells */}
+        {cells.map((cell, index) => {
+          const emotion = getVisibleEmotion(cell);
+          const today = isToday(cell);
+
+          return (
+            <div
+              key={`${cell.dateKey}-${index}`}
+              className={[
+                "relative flex flex-col items-center justify-center border-b border-r border-blue-200 py-1",
+                "min-h-[52px] tablet:min-h-[72px] pc:min-h-[91px]",
+                today ? "ring-2 ring-inset ring-illust-red" : "",
+                !cell.isCurrentMonth ? "bg-background/60" : "bg-white",
+              ].join(" ")}
+            >
+              {emotion ? (
+                <>
+                  <span className="text-xs font-bold leading-none text-gray-200 tablet:text-sm">
+                    {cell.day}
+                  </span>
+                  <Image
+                    src={EMOTION_ICONS[emotion]}
+                    alt={EMOTION_LABELS[emotion]}
+                    width={36}
+                    height={36}
+                    className="mt-1 h-6 w-6 tablet:h-8 tablet:w-8 pc:h-9 pc:w-9"
+                  />
+                </>
+              ) : (
+                <span
+                  className={[
+                    "text-sm font-semibold tablet:text-lg pc:text-xl",
+                    cell.isCurrentMonth ? "text-gray-200" : "text-gray-100/60",
+                  ].join(" ")}
+                >
+                  {cell.day}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
     </section>
   );
 }

--- a/src/widgets/mypage-activity/ui/EmotionPieChart.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionPieChart.tsx
@@ -2,23 +2,24 @@
 
 import { useMemo, type ReactElement } from "react";
 
+import Image from "next/image";
+
 import { Cell, Pie, PieChart, ResponsiveContainer } from "recharts";
 
 import type { Emotion, EmotionLog } from "@/entities/emotion-log";
 
 interface EmotionMeta {
   label: string;
-  emoji: string;
+  icon: string;
   color: string;
 }
 
-// Emojis and labels aligned with EmotionSelector to ensure consistency across the UI
 const EMOTION_META: Record<Emotion, EmotionMeta> = {
-  MOVED: { label: "감동", emoji: "🥹", color: "#48bb98" },
-  HAPPY: { label: "기쁨", emoji: "😊", color: "#fbc85b" },
-  WORRIED: { label: "고민", emoji: "😟", color: "#8e80e3" },
-  SAD: { label: "슬픔", emoji: "😔", color: "#5195ee" },
-  ANGRY: { label: "분노", emoji: "😡", color: "#e46e80" },
+  MOVED: { label: "감동", icon: "/icon/012-heart face.png", color: "#48bb98" },
+  HAPPY: { label: "기쁨", icon: "/icon/035-smiling face.png", color: "#fbc85b" },
+  WORRIED: { label: "고민", icon: "/icon/044-thinking.png", color: "#8e80e3" },
+  SAD: { label: "슬픔", icon: "/icon/034-sad.png", color: "#5195ee" },
+  ANGRY: { label: "분노", icon: "/icon/Frame 65.png", color: "#e46e80" },
 };
 
 const EMOTION_ORDER: Emotion[] = ["MOVED", "HAPPY", "WORRIED", "SAD", "ANGRY"];
@@ -57,11 +58,17 @@ export function EmotionPieChart({ emotionLogs }: EmotionPieChartProps): ReactEle
 
   if (chartData.length === 0) {
     return (
-      <section className="flex w-full flex-col rounded-2xl bg-white px-5 py-5 shadow-sm ring-1 ring-line-200">
-        <h2 className="mb-4 text-sm font-semibold text-black-700">감정 기록</h2>
-        <div className="flex flex-1 flex-col items-center justify-center gap-2 py-8">
-          <span className="text-4xl">📭</span>
-          <p className="text-sm text-black-300">이번 달 감정 기록이 없어요</p>
+      <section className="flex w-full flex-col rounded-2xl bg-white px-6 py-6 shadow-sm ring-1 ring-blue-200">
+        <h2 className="mb-4 text-xl font-semibold text-black-600">감정 차트</h2>
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 py-10">
+          <Image
+            src="/icon/035-smiling face.png"
+            alt="감정 없음"
+            width={48}
+            height={48}
+            className="h-12 w-12 opacity-30"
+          />
+          <p className="text-sm text-gray-300">이번 달 감정 기록이 없어요</p>
         </div>
       </section>
     );
@@ -70,20 +77,20 @@ export function EmotionPieChart({ emotionLogs }: EmotionPieChartProps): ReactEle
   const topEmotion = chartData.reduce((max, d) => (d.count > max.count ? d : max));
 
   return (
-    <section className="w-full rounded-2xl bg-white px-5 py-5 shadow-sm ring-1 ring-line-200">
-      <h2 className="mb-4 text-sm font-semibold text-black-700">감정 기록</h2>
+    <section className="w-full rounded-2xl bg-white px-6 py-6 shadow-sm ring-1 ring-blue-200">
+      <h2 className="mb-6 text-xl font-semibold text-black-600">감정 차트</h2>
 
-      <div className="flex items-center gap-6">
+      <div className="flex items-center gap-8">
         {/* Donut chart */}
-        <div className="relative h-[130px] w-[130px] shrink-0">
+        <div className="relative h-[140px] w-[140px] shrink-0">
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
                 data={chartData}
                 cx="50%"
                 cy="50%"
-                innerRadius={40}
-                outerRadius={58}
+                innerRadius={44}
+                outerRadius={62}
                 dataKey="count"
                 startAngle={90}
                 endAngle={-270}
@@ -99,24 +106,35 @@ export function EmotionPieChart({ emotionLogs }: EmotionPieChartProps): ReactEle
             </PieChart>
           </ResponsiveContainer>
 
-          <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
-            <span className="text-2xl leading-none">{EMOTION_META[topEmotion.emotion].emoji}</span>
-            <span className="mt-1 text-xs font-semibold text-black-500">
-              {topEmotion.percentage}%
+          <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1">
+            <Image
+              src={EMOTION_META[topEmotion.emotion].icon}
+              alt={EMOTION_META[topEmotion.emotion].label}
+              width={36}
+              height={36}
+              className="h-9 w-9"
+            />
+            <span className="text-xs font-semibold text-black-500">
+              {EMOTION_META[topEmotion.emotion].label}
             </span>
           </div>
         </div>
 
         {/* Legend */}
-        <ul className="flex flex-1 flex-col gap-2.5">
+        <ul className="flex flex-1 flex-col gap-3">
           {chartData.map(({ emotion, percentage }) => (
-            <li key={emotion} className="flex items-center gap-2.5">
-              <span
-                className="h-2.5 w-2.5 shrink-0 rounded-full"
-                style={{ backgroundColor: EMOTION_META[emotion].color }}
+            <li key={emotion} className="flex items-center gap-3">
+              <Image
+                src={EMOTION_META[emotion].icon}
+                alt={EMOTION_META[emotion].label}
+                width={24}
+                height={24}
+                className="h-6 w-6 shrink-0"
               />
-              <span className="w-10 text-xs text-black-400">{EMOTION_META[emotion].label}</span>
-              <div className="relative flex-1 overflow-hidden rounded-full bg-line-100 h-1.5">
+              <span className="w-8 shrink-0 text-sm text-black-400">
+                {EMOTION_META[emotion].label}
+              </span>
+              <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-blue-200">
                 <div
                   className="absolute left-0 top-0 h-full rounded-full transition-all duration-700"
                   style={{
@@ -125,7 +143,7 @@ export function EmotionPieChart({ emotionLogs }: EmotionPieChartProps): ReactEle
                   }}
                 />
               </div>
-              <span className="w-8 text-right text-xs font-semibold text-black-600">
+              <span className="w-9 shrink-0 text-right text-sm font-semibold text-black-600">
                 {percentage}%
               </span>
             </li>

--- a/src/widgets/mypage-activity/ui/MypageActivity.tsx
+++ b/src/widgets/mypage-activity/ui/MypageActivity.tsx
@@ -200,14 +200,12 @@ export function MypageActivity({ userId }: MypageActivityProps): ReactElement {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="grid gap-4 tablet:grid-cols-2">
-        <ErrorBoundary fallback={(_, reset) => <SectionErrorFallback reset={reset} />}>
-          <EmotionCalendar userId={userId} />
-        </ErrorBoundary>
-        <ErrorBoundary fallback={(_, reset) => <SectionErrorFallback reset={reset} />}>
-          <EmotionPieChart emotionLogs={monthlyLogs} />
-        </ErrorBoundary>
-      </div>
+      <ErrorBoundary fallback={(_, reset) => <SectionErrorFallback reset={reset} />}>
+        <EmotionCalendar userId={userId} />
+      </ErrorBoundary>
+      <ErrorBoundary fallback={(_, reset) => <SectionErrorFallback reset={reset} />}>
+        <EmotionPieChart emotionLogs={monthlyLogs} />
+      </ErrorBoundary>
 
       <div className="grid gap-4 pc:grid-cols-2">
         <MyEpigramList userId={userId} />


### PR DESCRIPTION
## ✏️ 작업 내용

마이페이지의 오늘의 감정 선택, 감정 캘린더, 감정 차트 섹션을 피그마 시안에 맞게 스타일 개선합니다.

- **오늘의 감정**: 날짜 형식 `YYYY.MM.DD`, 아이콘 컨테이너 크기·선택 스타일 피그마 시안 반영
- **감정 캘린더**: `react-calendar` 제거 → 커스텀 7열 CSS Grid 구현, 오늘 날짜 하이라이트, 감정 필터 드롭다운 추가
- **감정 차트**: 이모지 → 아이콘 이미지 교체, 제목 '감정 차트'로 변경, 범례 이미지 아이콘 적용
- **레이아웃**: 캘린더·차트 세로 단일 컬럼으로 변경

## 🗨️ 논의 사항 (참고 사항)

- `react-calendar` 라이브러리 의존성은 제거하지 않았습니다 (다른 곳에서 사용 여부 확인 필요)
- 캘린더 감정 필터는 클라이언트사이드에서 처리 (API 필터링 미지원)

## 기대효과

피그마 시안과 일치하는 마이페이지 UI 제공

Closes #246