### PR TITLE
fix: 마이페이지 모바일 반응형 레이아웃 개선 (#250)

### DIFF
--- a/src/views/mypage/ui/MypagePage.tsx
+++ b/src/views/mypage/ui/MypagePage.tsx
@@ -51,13 +51,13 @@ function EmotionSelector({
   isPending,
 }: EmotionSelectorProps): ReactElement {
   return (
-    <div className="w-full rounded-2xl bg-white px-6 py-6 shadow-sm ring-1 ring-blue-200">
-      <div className="mb-6 flex items-center justify-between">
-        <h2 className="text-xl font-semibold text-black-600">오늘의 감정</h2>
-        <span className="text-base text-blue-400">{TODAY_LABEL}</span>
+    <div className="w-full rounded-2xl bg-white px-4 py-5 shadow-sm ring-1 ring-blue-200 tablet:px-6 tablet:py-6">
+      <div className="mb-4 flex items-center justify-between tablet:mb-6">
+        <h2 className="text-base font-semibold text-black-600 tablet:text-xl">오늘의 감정</h2>
+        <span className="text-xs text-blue-400 tablet:text-base">{TODAY_LABEL}</span>
       </div>
 
-      <div className="flex items-start justify-around gap-2">
+      <div className="flex items-start justify-between gap-1 tablet:justify-around tablet:gap-2">
         {EMOTION_OPTIONS.map(({ value, icon, label }) => {
           const isSelected = selectedEmotion === value;
           return (
@@ -68,12 +68,12 @@ function EmotionSelector({
               disabled={isPending}
               aria-label={`${label} 감정 선택`}
               aria-pressed={isSelected}
-              className="group flex flex-col items-center gap-2 transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-50 active:scale-95"
+              className="group flex flex-col items-center gap-1.5 transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-50 active:scale-95 tablet:gap-2"
             >
               <span
                 className={[
-                  "flex h-16 w-16 items-center justify-center rounded-2xl transition-all duration-200",
-                  "tablet:h-20 tablet:w-20 pc:h-24 pc:w-24",
+                  "flex h-12 w-12 items-center justify-center rounded-xl transition-all duration-200",
+                  "tablet:h-16 tablet:w-16 tablet:rounded-2xl pc:h-20 pc:w-20",
                   isSelected
                     ? "border-4 border-illust-green"
                     : "bg-blue-400/15 group-hover:bg-blue-400/25",
@@ -84,12 +84,12 @@ function EmotionSelector({
                   alt={label}
                   width={48}
                   height={48}
-                  className="h-9 w-9 transition-transform duration-200 group-hover:scale-110 tablet:h-10 tablet:w-10 pc:h-12 pc:w-12"
+                  className="h-7 w-7 transition-transform duration-200 group-hover:scale-110 tablet:h-9 tablet:w-9 pc:h-12 pc:w-12"
                 />
               </span>
               <span
                 className={[
-                  "text-sm font-semibold transition-colors tablet:text-base pc:text-lg",
+                  "text-xs font-semibold transition-colors tablet:text-sm pc:text-base",
                   isSelected ? "text-black-600" : "text-gray-300",
                 ].join(" ")}
               >

--- a/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
@@ -149,21 +149,45 @@ export function EmotionCalendar({ userId }: EmotionCalendarProps): ReactElement 
   return (
     <section className="w-full rounded-2xl bg-white px-6 py-6 shadow-sm ring-1 ring-blue-200">
       {/* Header */}
-      <div className="mb-6 flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <h2 className="text-xl font-semibold text-black-600">
+      <div className="mb-4 flex flex-col gap-2 tablet:mb-6 tablet:flex-row tablet:items-center tablet:justify-between">
+        {/* Row 1: 연월 + 네비게이션 */}
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold text-black-600 tablet:text-xl">
             {year}년 {month}월
           </h2>
 
+          {/* Navigation (모바일: 연월 오른쪽, tablet+: 헤더 우측) */}
+          <div className="flex items-center gap-2 tablet:hidden">
+            <button
+              type="button"
+              aria-label="이전 달"
+              onClick={handlePrevMonth}
+              className="flex h-8 w-8 items-center justify-center rounded-full transition hover:bg-background active:scale-90"
+            >
+              <ChevronLeft className="h-4 w-4 text-black-600" strokeWidth={2.5} />
+            </button>
+            <button
+              type="button"
+              aria-label="다음 달"
+              onClick={handleNextMonth}
+              className="flex h-8 w-8 items-center justify-center rounded-full transition hover:bg-background active:scale-90"
+            >
+              <ChevronRight className="h-4 w-4 text-black-600" strokeWidth={2.5} />
+            </button>
+          </div>
+        </div>
+
+        {/* Row 2 (모바일) / Row 1 우측 (tablet+): 필터 + 네비게이션 */}
+        <div className="flex items-center justify-between tablet:justify-end tablet:gap-3">
           {/* Filter dropdown */}
           <div className="relative">
             <button
               type="button"
               onClick={() => setIsFilterOpen((v) => !v)}
-              className="flex items-center gap-1 rounded-xl bg-background px-3 py-1.5 text-sm font-semibold text-gray-200 transition hover:bg-blue-200"
+              className="flex items-center gap-1 rounded-xl bg-background px-3 py-1.5 text-xs font-semibold text-gray-200 transition hover:bg-blue-200 tablet:text-sm"
             >
               필터: {filterLabel}
-              <ChevronDown className="h-4 w-4" />
+              <ChevronDown className="h-3.5 w-3.5 tablet:h-4 tablet:w-4" />
             </button>
 
             {isFilterOpen && (
@@ -206,26 +230,26 @@ export function EmotionCalendar({ userId }: EmotionCalendarProps): ReactElement 
               </ul>
             )}
           </div>
-        </div>
 
-        {/* Navigation */}
-        <div className="flex items-center gap-3">
-          <button
-            type="button"
-            aria-label="이전 달"
-            onClick={handlePrevMonth}
-            className="flex h-9 w-9 items-center justify-center rounded-full transition hover:bg-background active:scale-90"
-          >
-            <ChevronLeft className="h-5 w-5 text-black-600" strokeWidth={2.5} />
-          </button>
-          <button
-            type="button"
-            aria-label="다음 달"
-            onClick={handleNextMonth}
-            className="flex h-9 w-9 items-center justify-center rounded-full transition hover:bg-background active:scale-90"
-          >
-            <ChevronRight className="h-5 w-5 text-black-600" strokeWidth={2.5} />
-          </button>
+          {/* Navigation (tablet+만 표시) */}
+          <div className="hidden items-center gap-2 tablet:flex">
+            <button
+              type="button"
+              aria-label="이전 달"
+              onClick={handlePrevMonth}
+              className="flex h-9 w-9 items-center justify-center rounded-full transition hover:bg-background active:scale-90"
+            >
+              <ChevronLeft className="h-5 w-5 text-black-600" strokeWidth={2.5} />
+            </button>
+            <button
+              type="button"
+              aria-label="다음 달"
+              onClick={handleNextMonth}
+              className="flex h-9 w-9 items-center justify-center rounded-full transition hover:bg-background active:scale-90"
+            >
+              <ChevronRight className="h-5 w-5 text-black-600" strokeWidth={2.5} />
+            </button>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## ✏️ 작업 내용

모바일(360px~)에서 발생하는 두 가지 레이아웃 깨짐 현상 수정

### 오늘의 감정 (`MypagePage.tsx`)
- 카드 패딩 `px-4 py-5` (모바일) / `px-6 py-6` (tablet+)로 반응형 적용
- 아이콘 컨테이너: 모바일 `h-12 w-12` → tablet `h-16 w-16` → pc `h-20 w-20`
- 아이콘 이미지: 모바일 `h-7 w-7` → tablet `h-9 w-9` → pc `h-12 w-12`
- 레이블: 모바일 `text-xs` → tablet `text-sm` → pc `text-base`
- 5개 아이콘 `justify-between`으로 균등 배치 (모바일), tablet+에서는 `justify-around`

### 감정 캘린더 (`EmotionCalendar.tsx`)
- 모바일: 1행(연월 + 화살표), 2행(필터 드롭다운) 2행 구조
- tablet+: 기존 1행 레이아웃 유지
- 화살표 버튼 모바일/tablet+ 각각 별도 렌더링(`hidden`/`tablet:flex`)

## 🗨️ 논의 사항 (참고 사항)

없음

## 기대효과

모바일 화면에서 오늘의 감정 아이콘 오버플로우 및 캘린더 헤더 줄바꿈 현상 해소

Closes #250