### PR TITLE
fix: 오늘의 에피그램 ZodError 수정 - isLiked 스키마 불일치

### DIFF
--- a/src/entities/epigram/api/useTodayEpigram.ts
+++ b/src/entities/epigram/api/useTodayEpigram.ts
@@ -2,15 +2,17 @@ import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 
 import { apiClient } from "@/shared/api/client";
 
-import { epigramDetailSchema, type EpigramDetail } from "../model/schema";
+import { epigramSchema, type Epigram } from "../model/schema";
 
-export function useTodayEpigram(): UseQueryResult<EpigramDetail | null, Error> {
+// /today 엔드포인트는 인증 없는 공개 API라 isLiked를 반환하지 않음.
+// swagger의 EpigramDetailType 명세와 실제 응답이 불일치하므로 epigramSchema를 사용한다.
+export function useTodayEpigram(): UseQueryResult<Epigram | null, Error> {
   return useQuery({
     queryKey: ["epigrams", "today"],
     queryFn: async () => {
       const response = await apiClient.get<unknown>("/api/epigrams/today");
       if (response.data == null || typeof response.data !== "object") return null;
-      return epigramDetailSchema.parse(response.data);
+      return epigramSchema.parse(response.data);
     },
   });
 }


### PR DESCRIPTION
## 요약

- `useTodayEpigram`에서 `epigramDetailSchema` → `epigramSchema`로 교체
- `/today` 엔드포인트는 인증 없는 공개 API라 `isLiked` 필드를 반환하지 않음
- swagger 명세(`EpigramDetailType`)와 실제 응답이 불일치 → `epigramSchema`(isLiked 없는 기본 스키마)로 파싱

## 원인

```
ZodError: [{ "code": "invalid_type", "expected": "boolean", "received": "undefined", "path": ["isLiked"] }]
```

`epigramDetailSchema`는 `isLiked: z.boolean()`을 필수로 요구하지만 `/today` 공개 API 응답에는 해당 필드가 없음.

## 테스트 플랜

- [ ] `/epigrams` 페이지 접속 시 오늘의 에피그램 섹션 정상 렌더링 확인
- [ ] ErrorBoundary가 더 이상 ZodError를 잡지 않는지 확인
- [ ] 오늘의 에피그램이 없을 때 empty state 정상 표시 확인

Closes #256

🤖 Generated with [Claude Code](https://claude.ai/claude-code)