### PR TITLE
fix: 에피그램 작성 성공 시 에러 메시지 표시 및 상세 페이지 미이동

### DIFF
--- a/src/entities/epigram/api/createEpigram.ts
+++ b/src/entities/epigram/api/createEpigram.ts
@@ -1,6 +1,6 @@
 import { apiClient } from "@/shared/api/client";
 
-import { epigramDetailSchema, type EpigramDetail } from "../model/schema";
+import { epigramSchema, type Epigram } from "../model/schema";
 
 export interface CreateEpigramRequest {
   content: string;
@@ -10,7 +10,7 @@ export interface CreateEpigramRequest {
   tags: string[];
 }
 
-export async function createEpigram(data: CreateEpigramRequest): Promise<EpigramDetail> {
+export async function createEpigram(data: CreateEpigramRequest): Promise<Epigram> {
   const response = await apiClient.post<unknown>("/api/epigrams", data);
-  return epigramDetailSchema.parse(response.data);
+  return epigramSchema.parse(response.data);
 }


### PR DESCRIPTION
## ✏️ 작업 내용

- `createEpigram.ts`에서 POST `/epigrams` 응답 파싱 스키마를 `epigramDetailSchema` → `epigramSchema`로 교체
  - `epigramDetailSchema`는 `isLiked: boolean` 필드가 필수인데, 해당 엔드포인트는 `EpigramListType`을 반환하여 `isLiked`가 없음 → Zod 파싱 실패 → mutation 에러 분기 → 에러 메시지 표시, `onSuccess` 미호출로 상세 페이지 미이동

## 🗨️ 논의 사항 (참고 사항)

- Swagger 확인 결과 POST `/epigrams`는 `EpigramListType` 반환 (`isLiked` 미포함). `epigramDetailSchema`는 GET `/epigrams/:id` 전용으로만 사용해야 함

## 기대효과

- 에피그램 작성 성공 시 에러 메시지가 표시되지 않고 `/epigrams/:id` 상세 페이지로 즉시 이동

Closes #271