### PR TITLE
perf: /feeds, /epigrams 페이지 React Query 서버 prefetch + HydrationBoundary 적용

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,5 @@ jobs:
         run: npm run build
         env:
           NEXT_TELEMETRY_DISABLED: 1
-          # 빌드에 필요한 환경변수는 GitHub Secrets에 등록 후 아래에 추가
-          # BACKEND_URL: ${{ secrets.BACKEND_URL }}
-          # TEAM_ID: ${{ secrets.TEAM_ID }}
+          BACKEND_URL: ${{ secrets.BACKEND_URL }}
+          TEAM_ID: ${{ secrets.TEAM_ID }}

--- a/src/app/epigrams/page.tsx
+++ b/src/app/epigrams/page.tsx
@@ -1,7 +1,54 @@
 import type { ReactElement } from "react";
 
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+
+import { fetchRecentCommentsPageServer } from "@/entities/comment/api/server";
+import { fetchEpigramsPageServer, fetchTodayEpigramServer } from "@/entities/epigram/api/server";
 import { EpigramsPage } from "@/views/epigrams";
 
-export default function Page(): ReactElement {
-  return <EpigramsPage />;
+// Must match the values used in EpigramFeed and RecentComments widgets
+const FEED_PAGE_SIZE = 5;
+const COMMENTS_PAGE_SIZE = 4;
+
+export default async function Page(): Promise<ReactElement> {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { staleTime: 60 * 1000 } },
+  });
+
+  await Promise.all([
+    queryClient
+      .prefetchQuery({
+        queryKey: ["epigrams", "today"],
+        queryFn: fetchTodayEpigramServer,
+      })
+      .catch(() => {}),
+    queryClient
+      .prefetchInfiniteQuery({
+        queryKey: ["epigrams", { limit: FEED_PAGE_SIZE, keyword: undefined, writerId: undefined }],
+        queryFn: ({ pageParam }) =>
+          fetchEpigramsPageServer({
+            limit: FEED_PAGE_SIZE,
+            pageParam: pageParam as number | undefined,
+          }),
+        initialPageParam: undefined as number | undefined,
+      })
+      .catch(() => {}),
+    queryClient
+      .prefetchInfiniteQuery({
+        queryKey: ["comments", { limit: COMMENTS_PAGE_SIZE }],
+        queryFn: ({ pageParam }) =>
+          fetchRecentCommentsPageServer({
+            limit: COMMENTS_PAGE_SIZE,
+            pageParam: pageParam as number | undefined,
+          }),
+        initialPageParam: undefined as number | undefined,
+      })
+      .catch(() => {}),
+  ]);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <EpigramsPage />
+    </HydrationBoundary>
+  );
 }

--- a/src/app/feeds/page.tsx
+++ b/src/app/feeds/page.tsx
@@ -1,7 +1,33 @@
 import type { ReactElement } from "react";
 
+import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+
+import { fetchEpigramsPageServer } from "@/entities/epigram/api/server";
 import { FeedsPage } from "@/views/feeds";
 
-export default function FeedsRoute(): ReactElement {
-  return <FeedsPage />;
+// Must match FEEDS_PAGE_SIZE in FeedsPage
+const FEEDS_PAGE_SIZE = 10;
+
+export default async function FeedsRoute(): Promise<ReactElement> {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { staleTime: 60 * 1000 } },
+  });
+
+  await queryClient
+    .prefetchInfiniteQuery({
+      queryKey: ["epigrams", { limit: FEEDS_PAGE_SIZE, keyword: undefined, writerId: undefined }],
+      queryFn: ({ pageParam }) =>
+        fetchEpigramsPageServer({
+          limit: FEEDS_PAGE_SIZE,
+          pageParam: pageParam as number | undefined,
+        }),
+      initialPageParam: undefined as number | undefined,
+    })
+    .catch(() => {});
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <FeedsPage />
+    </HydrationBoundary>
+  );
 }

--- a/src/entities/comment/api/server.ts
+++ b/src/entities/comment/api/server.ts
@@ -1,0 +1,25 @@
+// Server-only: DO NOT import in client components
+import { BACKEND_BASE } from "@/shared/config/backend";
+
+import { commentListResponseSchema } from "../model/schema";
+import type { CommentListResponse } from "../model/schema";
+
+interface FetchCommentsPageParams {
+  limit: number;
+  pageParam?: number;
+}
+
+export async function fetchRecentCommentsPageServer({
+  limit,
+  pageParam,
+}: FetchCommentsPageParams): Promise<CommentListResponse> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (pageParam !== undefined) params.set("cursor", String(pageParam));
+
+  const res = await fetch(`${BACKEND_BASE}/comments?${params}`, {
+    next: { revalidate: 30, tags: ["comments"] },
+  });
+
+  if (!res.ok) throw new Error(`Failed to fetch comments: ${res.status}`);
+  return commentListResponseSchema.parse(await res.json());
+}

--- a/src/entities/comment/api/server.ts
+++ b/src/entities/comment/api/server.ts
@@ -18,6 +18,7 @@ export async function fetchRecentCommentsPageServer({
 
   const res = await fetch(`${BACKEND_BASE}/comments?${params}`, {
     next: { revalidate: 30, tags: ["comments"] },
+    signal: AbortSignal.timeout(5000),
   });
 
   if (!res.ok) throw new Error(`Failed to fetch comments: ${res.status}`);

--- a/src/entities/epigram/api/server.ts
+++ b/src/entities/epigram/api/server.ts
@@ -24,6 +24,7 @@ export async function fetchEpigramsPageServer({
 
   const res = await fetch(`${BACKEND_BASE}/epigrams?${params}`, {
     next: { revalidate: 30, tags: ["epigrams"] },
+    signal: AbortSignal.timeout(5000),
   });
 
   if (!res.ok) throw new Error(`Failed to fetch epigrams: ${res.status}`);
@@ -33,6 +34,7 @@ export async function fetchEpigramsPageServer({
 export async function fetchTodayEpigramServer(): Promise<Epigram | null> {
   const res = await fetch(`${BACKEND_BASE}/epigrams/today`, {
     next: { revalidate: 60, tags: ["epigrams", "epigrams-today"] },
+    signal: AbortSignal.timeout(5000),
   });
 
   if (!res.ok) return null;

--- a/src/entities/epigram/api/server.ts
+++ b/src/entities/epigram/api/server.ts
@@ -1,0 +1,43 @@
+// Server-only: DO NOT import in client components
+import { BACKEND_BASE } from "@/shared/config/backend";
+
+import { epigramListResponseSchema, epigramSchema } from "../model/schema";
+import type { Epigram, EpigramListResponse } from "../model/schema";
+
+interface FetchEpigramsPageParams {
+  limit: number;
+  pageParam?: number;
+  keyword?: string;
+  writerId?: number;
+}
+
+export async function fetchEpigramsPageServer({
+  limit,
+  pageParam,
+  keyword,
+  writerId,
+}: FetchEpigramsPageParams): Promise<EpigramListResponse> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (pageParam !== undefined) params.set("cursor", String(pageParam));
+  if (keyword) params.set("keyword", keyword);
+  if (writerId !== undefined) params.set("writerId", String(writerId));
+
+  const res = await fetch(`${BACKEND_BASE}/epigrams?${params}`, {
+    next: { revalidate: 30, tags: ["epigrams"] },
+  });
+
+  if (!res.ok) throw new Error(`Failed to fetch epigrams: ${res.status}`);
+  return epigramListResponseSchema.parse(await res.json());
+}
+
+export async function fetchTodayEpigramServer(): Promise<Epigram | null> {
+  const res = await fetch(`${BACKEND_BASE}/epigrams/today`, {
+    next: { revalidate: 60, tags: ["epigrams", "epigrams-today"] },
+  });
+
+  if (!res.ok) return null;
+
+  const data: unknown = await res.json();
+  if (data == null || typeof data !== "object") return null;
+  return epigramSchema.parse(data);
+}

--- a/src/shared/config/backend.ts
+++ b/src/shared/config/backend.ts
@@ -1,0 +1,2 @@
+// Server-only: backend base URL for direct server-side fetch (bypassing BFF proxy)
+export const BACKEND_BASE = `${process.env.BACKEND_URL}/${process.env.TEAM_ID}`;


### PR DESCRIPTION
## ✏️ 작업 내용

### 문제
`/feeds`, `/epigrams` 페이지가 완전 CSR로 동작해 초기 접속 시 빈 스켈레톤이 먼저 보임.

### 변경 사항

**신규 파일**
- `src/shared/config/backend.ts` — `BACKEND_BASE` 상수 (서버 전용, BFF 프록시 우회)
- `src/entities/epigram/api/server.ts` — `fetchEpigramsPageServer`, `fetchTodayEpigramServer`
- `src/entities/comment/api/server.ts` — `fetchRecentCommentsPageServer`

**수정 파일**
- `src/app/epigrams/page.tsx` — async 서버 컴포넌트, 3개 쿼리 prefetch (today 에피그램, 에피그램 목록, 최신 댓글)
- `src/app/feeds/page.tsx` — async 서버 컴포넌트, 에피그램 목록 prefetch

### 구현 세부 사항
- 서버 `QueryClient`에 `staleTime: 60 * 1000` 설정 → 클라이언트가 hydrated 데이터를 즉시 stale 처리하지 않도록
- 각 prefetch에 `.catch(() => {})` → 백엔드 에러 시 페이지 렌더 블락 방지
- 서버 fetch는 BFF 프록시 대신 백엔드에 직접 요청 (`next: { revalidate: 30, tags: [...] }`)

### 빌드 결과
```
○ /epigrams    Revalidate: 30s ✅
○ /feeds       Revalidate: 30s ✅
```

## 🗨️ 논의 사항 (참고 사항)

- 클라이언트 무한 스크롤, 인터랙션은 기존 그대로 동작 (쿼리 키 완전히 일치)
- `// Must match ...` 주석으로 페이지 사이즈 상수와 위젯 상수 싱크 명시

## 기대효과

- 초기 로딩 시 스켈레톤 없이 즉시 콘텐츠 표시
- ISR 30초 캐싱으로 백엔드 부하 감소

Closes #279