### PR TITLE
fix: 프로필 이미지 업로드 실패 버그 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
   reactCompiler: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "sprint-fe-project.s3.ap-northeast-2.amazonaws.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/api/[...path]/route.ts
+++ b/src/app/api/[...path]/route.ts
@@ -44,7 +44,7 @@ async function callBackend(
   url: string,
   method: string,
   accessToken: string | undefined,
-  body: string | undefined,
+  body: ArrayBuffer | undefined,
   contentType: string | null
 ): Promise<Response> {
   const headers: HeadersInit = {};
@@ -137,7 +137,9 @@ async function handler(
   const accessToken = request.cookies.get("accessToken")?.value;
   const contentType = request.headers.get("Content-Type");
   const body =
-    request.method !== "GET" && request.method !== "HEAD" ? await request.text() : undefined;
+    request.method !== "GET" && request.method !== "HEAD"
+      ? await request.arrayBuffer()
+      : undefined;
 
   const refreshToken = request.cookies.get("refreshToken")?.value;
 

--- a/src/app/api/[...path]/route.ts
+++ b/src/app/api/[...path]/route.ts
@@ -44,20 +44,11 @@ async function callBackend(
   url: string,
   method: string,
   accessToken: string | undefined,
-  body: BodyInit | undefined,
-  contentType: string | null
+  body: BodyInit | undefined
 ): Promise<Response> {
-  const headers: HeadersInit = {};
-
-  // multipart/form-data는 Content-Type을 설정하지 않는다 —
-  // FormData를 body로 넘기면 fetch가 올바른 boundary를 자동 생성한다.
-  if (contentType && !contentType.includes("multipart/form-data")) {
-    headers["Content-Type"] = contentType;
-  }
-
-  if (accessToken) {
-    headers["Authorization"] = `Bearer ${accessToken}`;
-  }
+  const headers: HeadersInit = {
+    ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+  };
 
   return fetch(url, {
     method,
@@ -137,20 +128,12 @@ async function handler(
 
   const backendUrl = buildBackendUrl(path, request.nextUrl.searchParams);
   const accessToken = request.cookies.get("accessToken")?.value;
-  const contentType = request.headers.get("Content-Type");
 
-  // multipart/form-data는 원본 바이트를 Blob으로 감싸서 그대로 전달한다.
-  // Blob.type에 boundary가 포함된 원본 Content-Type이 담기므로
-  // fetch가 이를 그대로 사용해 경계값 불일치 없이 백엔드로 전달된다.
-  // 그 외 요청은 arrayBuffer로 읽어 바이너리를 보존한다.
+  // blob()으로 읽으면 원본 바이트와 Content-Type(boundary 포함)이 그대로 보존된다.
+  // fetch에 Blob을 body로 넘기면 Blob.type이 Content-Type 헤더로 자동 사용된다.
   let body: BodyInit | undefined;
   if (request.method !== "GET" && request.method !== "HEAD") {
-    if (contentType?.includes("multipart/form-data")) {
-      const rawBytes = await request.arrayBuffer();
-      body = new Blob([rawBytes], { type: contentType });
-    } else {
-      body = await request.arrayBuffer();
-    }
+    body = await request.blob();
   }
 
   const refreshToken = request.cookies.get("refreshToken")?.value;
@@ -171,8 +154,7 @@ async function handler(
       backendUrl,
       request.method,
       newAccessToken,
-      body,
-      contentType
+      body
     );
 
     const retryResponse =
@@ -194,8 +176,7 @@ async function handler(
     backendUrl,
     request.method,
     accessToken,
-    body,
-    contentType
+    body
   );
 
   // 401: refreshToken으로 갱신 후 재시도
@@ -214,8 +195,7 @@ async function handler(
       backendUrl,
       request.method,
       newAccessToken,
-      body,
-      contentType
+      body
     );
 
     const retryResponse =

--- a/src/app/api/[...path]/route.ts
+++ b/src/app/api/[...path]/route.ts
@@ -44,9 +44,13 @@ async function callBackend(
   url: string,
   method: string,
   accessToken: string | undefined,
-  body: BodyInit | undefined
+  body: BodyInit | undefined,
+  contentType: string
 ): Promise<Response> {
+  const isMultipart = contentType.includes("multipart/form-data");
+
   const headers: HeadersInit = {
+    "Content-Type": isMultipart ? contentType : "application/json",
     ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
   };
 
@@ -128,12 +132,14 @@ async function handler(
 
   const backendUrl = buildBackendUrl(path, request.nextUrl.searchParams);
   const accessToken = request.cookies.get("accessToken")?.value;
+  const contentType = request.headers.get("Content-Type") ?? "";
+  const isMultipart = contentType.includes("multipart/form-data");
 
-  // blob()으로 읽으면 원본 바이트와 Content-Type(boundary 포함)이 그대로 보존된다.
-  // fetch에 Blob을 body로 넘기면 Blob.type이 Content-Type 헤더로 자동 사용된다.
   let body: BodyInit | undefined;
   if (request.method !== "GET" && request.method !== "HEAD") {
-    body = await request.blob();
+    body = isMultipart
+      ? await request.blob()
+      : JSON.stringify(await request.json().catch(() => ({})));
   }
 
   const refreshToken = request.cookies.get("refreshToken")?.value;
@@ -154,7 +160,8 @@ async function handler(
       backendUrl,
       request.method,
       newAccessToken,
-      body
+      body,
+      contentType
     );
 
     const retryResponse =
@@ -176,7 +183,8 @@ async function handler(
     backendUrl,
     request.method,
     accessToken,
-    body
+    body,
+    contentType
   );
 
   // 401: refreshToken으로 갱신 후 재시도
@@ -195,7 +203,8 @@ async function handler(
       backendUrl,
       request.method,
       newAccessToken,
-      body
+      body,
+      contentType
     );
 
     const retryResponse =

--- a/src/app/api/[...path]/route.ts
+++ b/src/app/api/[...path]/route.ts
@@ -44,12 +44,14 @@ async function callBackend(
   url: string,
   method: string,
   accessToken: string | undefined,
-  body: ArrayBuffer | undefined,
+  body: BodyInit | undefined,
   contentType: string | null
 ): Promise<Response> {
   const headers: HeadersInit = {};
 
-  if (contentType) {
+  // multipart/form-data는 Content-Type을 설정하지 않는다 —
+  // FormData를 body로 넘기면 fetch가 올바른 boundary를 자동 생성한다.
+  if (contentType && !contentType.includes("multipart/form-data")) {
     headers["Content-Type"] = contentType;
   }
 
@@ -136,10 +138,16 @@ async function handler(
   const backendUrl = buildBackendUrl(path, request.nextUrl.searchParams);
   const accessToken = request.cookies.get("accessToken")?.value;
   const contentType = request.headers.get("Content-Type");
-  const body =
-    request.method !== "GET" && request.method !== "HEAD"
-      ? await request.arrayBuffer()
-      : undefined;
+
+  // multipart/form-data는 FormData로 파싱해서 그대로 전달한다.
+  // fetch가 올바른 boundary를 자동 생성하므로 Content-Type을 별도로 지정하지 않아도 된다.
+  // 그 외 요청은 arrayBuffer로 읽어 바이너리를 보존한다.
+  let body: BodyInit | undefined;
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    body = contentType?.includes("multipart/form-data")
+      ? await request.formData()
+      : await request.arrayBuffer();
+  }
 
   const refreshToken = request.cookies.get("refreshToken")?.value;
 

--- a/src/app/api/[...path]/route.ts
+++ b/src/app/api/[...path]/route.ts
@@ -139,14 +139,18 @@ async function handler(
   const accessToken = request.cookies.get("accessToken")?.value;
   const contentType = request.headers.get("Content-Type");
 
-  // multipart/form-data는 FormData로 파싱해서 그대로 전달한다.
-  // fetch가 올바른 boundary를 자동 생성하므로 Content-Type을 별도로 지정하지 않아도 된다.
+  // multipart/form-data는 원본 바이트를 Blob으로 감싸서 그대로 전달한다.
+  // Blob.type에 boundary가 포함된 원본 Content-Type이 담기므로
+  // fetch가 이를 그대로 사용해 경계값 불일치 없이 백엔드로 전달된다.
   // 그 외 요청은 arrayBuffer로 읽어 바이너리를 보존한다.
   let body: BodyInit | undefined;
   if (request.method !== "GET" && request.method !== "HEAD") {
-    body = contentType?.includes("multipart/form-data")
-      ? await request.formData()
-      : await request.arrayBuffer();
+    if (contentType?.includes("multipart/form-data")) {
+      const rawBytes = await request.arrayBuffer();
+      body = new Blob([rawBytes], { type: contentType });
+    } else {
+      body = await request.arrayBuffer();
+    }
   }
 
   const refreshToken = request.cookies.get("refreshToken")?.value;

--- a/src/shared/api/uploadImage.ts
+++ b/src/shared/api/uploadImage.ts
@@ -11,7 +11,11 @@ export async function uploadImage(file: File): Promise<string> {
   const formData = new FormData();
   formData.append("image", file);
 
-  const response = await apiClient.post<{ url: string }>("/api/images/upload", formData);
+  // Content-Type을 undefined로 지워야 브라우저가 boundary 포함한 multipart/form-data를 자동 설정한다.
+  // axios 기본 헤더(application/json)가 살아있으면 BFF가 JSON으로 오인해 파싱 실패한다.
+  const response = await apiClient.post<{ url: string }>("/api/images/upload", formData, {
+    headers: { "Content-Type": undefined },
+  });
 
   return response.data.url;
 }


### PR DESCRIPTION
## ✏️ 작업 내용

- `src/app/api/[...path]/route.ts`: 요청 body 처리를 `request.text()` → `isMultipart` 분기로 수정
  - multipart/form-data: `request.blob()` — 원본 바이트와 Content-Type(boundary 포함) 보존
  - 그 외: `JSON.stringify(request.json())` — JSON 직렬화
- `src/shared/api/uploadImage.ts`: axios 요청 시 `headers: { "Content-Type": undefined }` 추가 — axios 기본 헤더가 boundary를 덮어쓰는 문제 수정
- `next.config.ts`: S3 이미지 호스트(`sprint-fe-project.s3.ap-northeast-2.amazonaws.com`)를 `next/image` 허용 목록에 추가

## 🗨️ 논의 사항 (참고 사항)

**근본 원인**: axios 인스턴스 기본 헤더에 `"Content-Type": "application/json"`이 설정되어 있어, FormData 전송 시에도 이 헤더가 유지됨. BFF가 `Content-Type: application/json`으로 수신하면 `isMultipart = false`로 판단해 `request.json()` 파싱을 시도하다 실패, 빈 body(`{}`)를 백엔드로 전달하여 500 발생.

## 기대효과

- 프로필 이미지 업로드가 정상적으로 동작
- 업로드된 이미지가 `next/image`로 정상 렌더링

Closes #287