### PR TITLE
refactor: BFF proxy 관심사 분리 — 엔드포인트 분리 및 공통 유틸 추출

### DIFF
--- a/src/app/api/[...path]/route.ts
+++ b/src/app/api/[...path]/route.ts
@@ -1,118 +1,28 @@
 import { NextRequest, NextResponse } from "next/server";
 
-// 인증 엔드포인트: 백엔드 응답의 토큰을 HttpOnly 쿠키로 변환해야 하는 경로
-const AUTH_TOKEN_ENDPOINTS = new Set(["auth/signUp", "auth/signIn", "auth/signIn/kakao"]);
+import { setAccessTokenCookie } from "../_lib/cookies";
+import {
+  buildBackendUrl,
+  readRequestBody,
+  callBackend,
+  buildProxyResponse,
+  attemptTokenRefresh,
+  buildUnauthorizedResponse,
+} from "../_lib/proxy";
 
-const IS_PRODUCTION = process.env.NODE_ENV === "production";
-
-function setAccessTokenCookie(response: NextResponse, value: string): void {
-  response.cookies.set({
-    name: "accessToken",
-    value,
-    httpOnly: true,
-    sameSite: "strict",
-    secure: IS_PRODUCTION,
-    path: "/",
-    maxAge: 3600,
-  });
-}
-
-function setRefreshTokenCookie(response: NextResponse, value: string): void {
-  response.cookies.set({
-    name: "refreshToken",
-    value,
-    httpOnly: true,
-    sameSite: "strict",
-    secure: IS_PRODUCTION,
-    path: "/",
-    maxAge: 604800,
-  });
-}
-
-function clearAuthCookies(response: NextResponse): void {
-  response.cookies.set({ name: "accessToken", value: "", path: "/", maxAge: 0 });
-  response.cookies.set({ name: "refreshToken", value: "", path: "/", maxAge: 0 });
-}
-
-function buildBackendUrl(path: string, searchParams: URLSearchParams): string {
-  const base = `${process.env.BACKEND_URL}/${process.env.TEAM_ID}/${path}`;
-  const query = searchParams.toString();
-  return query ? `${base}?${query}` : base;
-}
-
-async function callBackend(
-  url: string,
+async function withTokenRefresh(
+  backendUrl: string,
   method: string,
-  accessToken: string | undefined,
   body: BodyInit | undefined,
-  contentType: string
-): Promise<Response> {
-  const isMultipart = contentType.includes("multipart/form-data");
+  contentType: string,
+  refreshToken: string
+): Promise<NextResponse> {
+  const newAccessToken = await attemptTokenRefresh(refreshToken);
+  if (!newAccessToken) return buildUnauthorizedResponse();
 
-  const headers: HeadersInit = {
-    "Content-Type": isMultipart ? contentType : "application/json",
-    ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
-  };
-
-  return fetch(url, {
-    method,
-    headers,
-    body,
-    // 백엔드가 Next.js 캐시 없이 항상 최신 데이터를 반환하도록 강제
-    cache: "no-store",
-  });
-}
-
-interface BackendAuthPayload {
-  accessToken?: string;
-  refreshToken?: string;
-  [key: string]: unknown;
-}
-
-async function handleAuthEndpointResponse(backendResponse: Response): Promise<NextResponse> {
-  const contentType = backendResponse.headers.get("Content-Type") ?? "";
-  if (!contentType.includes("application/json")) {
-    return new NextResponse(backendResponse.body, { status: backendResponse.status });
-  }
-
-  const payload = (await backendResponse.json()) as BackendAuthPayload;
-  const { accessToken, refreshToken, ...rest } = payload;
-
-  const response = NextResponse.json(rest, { status: backendResponse.status });
-
-  if (accessToken) {
-    setAccessTokenCookie(response, accessToken);
-  }
-  if (refreshToken) {
-    setRefreshTokenCookie(response, refreshToken);
-  }
-
-  return response;
-}
-
-async function attemptTokenRefresh(refreshToken: string): Promise<string | null> {
-  const refreshUrl = `${process.env.BACKEND_URL}/${process.env.TEAM_ID}/auth/refresh-token`;
-
-  try {
-    const response = await fetch(refreshUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ refreshToken }),
-      cache: "no-store",
-    });
-
-    if (!response.ok) return null;
-
-    const data = (await response.json()) as { accessToken?: string };
-    return data.accessToken ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function buildUnauthorizedResponse(): NextResponse {
-  const response = NextResponse.json({ message: "Unauthorized" }, { status: 401 });
-  clearAuthCookies(response);
+  const backendResponse = await callBackend(backendUrl, method, newAccessToken, body, contentType);
+  const response = buildProxyResponse(backendResponse);
+  setAccessTokenCookie(response, newAccessToken);
   return response;
 }
 
@@ -123,115 +33,30 @@ async function handler(
   const { path: pathSegments } = await context.params;
   const path = pathSegments.join("/");
 
-  // 로그아웃: 백엔드 호출 없이 쿠키만 삭제
-  if (path === "auth/logout" && request.method === "POST") {
-    const response = NextResponse.json({ success: true }, { status: 200 });
-    clearAuthCookies(response);
-    return response;
-  }
-
   const backendUrl = buildBackendUrl(path, request.nextUrl.searchParams);
   const accessToken = request.cookies.get("accessToken")?.value;
-  const contentType = request.headers.get("Content-Type") ?? "";
-  const isMultipart = contentType.includes("multipart/form-data");
-
-  let body: BodyInit | undefined;
-  if (request.method !== "GET" && request.method !== "HEAD") {
-    body = isMultipart
-      ? await request.blob()
-      : JSON.stringify(await request.json().catch(() => ({})));
-  }
-
   const refreshToken = request.cookies.get("refreshToken")?.value;
+  const contentType = request.headers.get("Content-Type") ?? "";
 
-  // 토큰이 전혀 없으면 백엔드 요청 없이 즉시 null 반환 — 브라우저 콘솔 401 방지
+  // 토큰이 전혀 없으면 백엔드 요청 없이 null 반환 — 브라우저 콘솔 401 방지
   if (!accessToken && !refreshToken && path === "users/me") {
     return NextResponse.json(null, { status: 200 });
   }
 
-  // accessToken 없이 refreshToken만 있으면 바로 갱신 시도
+  const body = await readRequestBody(request);
+
   if (!accessToken && refreshToken) {
-    const newAccessToken = await attemptTokenRefresh(refreshToken);
-    if (!newAccessToken) {
-      return buildUnauthorizedResponse();
-    }
-
-    const backendResponseWithNewToken = await callBackend(
-      backendUrl,
-      request.method,
-      newAccessToken,
-      body,
-      contentType
-    );
-
-    const retryResponse =
-      AUTH_TOKEN_ENDPOINTS.has(path) && backendResponseWithNewToken.ok
-        ? await handleAuthEndpointResponse(backendResponseWithNewToken)
-        : new NextResponse(backendResponseWithNewToken.body, {
-            status: backendResponseWithNewToken.status,
-            headers: {
-              "Content-Type":
-                backendResponseWithNewToken.headers.get("Content-Type") ?? "application/json",
-            },
-          });
-
-    setAccessTokenCookie(retryResponse, newAccessToken);
-    return retryResponse;
+    return withTokenRefresh(backendUrl, request.method, body, contentType, refreshToken);
   }
 
-  let backendResponse = await callBackend(
-    backendUrl,
-    request.method,
-    accessToken,
-    body,
-    contentType
-  );
+  const backendResponse = await callBackend(backendUrl, request.method, accessToken, body, contentType);
 
-  // 401: refreshToken으로 갱신 후 재시도
   if (backendResponse.status === 401) {
-    if (!refreshToken) {
-      return buildUnauthorizedResponse();
-    }
-
-    const newAccessToken = await attemptTokenRefresh(refreshToken);
-    if (!newAccessToken) {
-      return buildUnauthorizedResponse();
-    }
-
-    // 새 토큰으로 재시도
-    backendResponse = await callBackend(
-      backendUrl,
-      request.method,
-      newAccessToken,
-      body,
-      contentType
-    );
-
-    const retryResponse =
-      AUTH_TOKEN_ENDPOINTS.has(path) && backendResponse.ok
-        ? await handleAuthEndpointResponse(backendResponse)
-        : new NextResponse(backendResponse.body, {
-            status: backendResponse.status,
-            headers: {
-              "Content-Type": backendResponse.headers.get("Content-Type") ?? "application/json",
-            },
-          });
-
-    // 새 accessToken을 쿠키에 갱신
-    setAccessTokenCookie(retryResponse, newAccessToken);
-    return retryResponse;
+    if (!refreshToken) return buildUnauthorizedResponse();
+    return withTokenRefresh(backendUrl, request.method, body, contentType, refreshToken);
   }
 
-  // 인증 엔드포인트 성공: 토큰 → 쿠키 변환
-  if (AUTH_TOKEN_ENDPOINTS.has(path) && backendResponse.ok) {
-    return handleAuthEndpointResponse(backendResponse);
-  }
-
-  // 일반 응답: 그대로 중계
-  return new NextResponse(backendResponse.body, {
-    status: backendResponse.status,
-    headers: { "Content-Type": backendResponse.headers.get("Content-Type") ?? "application/json" },
-  });
+  return buildProxyResponse(backendResponse);
 }
 
 export const GET = handler;

--- a/src/app/api/_lib/cookies.ts
+++ b/src/app/api/_lib/cookies.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+const IS_PRODUCTION = process.env.NODE_ENV === "production";
+
+const COOKIE_BASE = {
+  httpOnly: true,
+  sameSite: "strict" as const,
+  secure: IS_PRODUCTION,
+  path: "/",
+};
+
+export function setAccessTokenCookie(response: NextResponse, value: string): void {
+  response.cookies.set({ name: "accessToken", value, ...COOKIE_BASE, maxAge: 3600 });
+}
+
+export function setRefreshTokenCookie(response: NextResponse, value: string): void {
+  response.cookies.set({ name: "refreshToken", value, ...COOKIE_BASE, maxAge: 604800 });
+}
+
+export function clearAuthCookies(response: NextResponse): void {
+  response.cookies.set({ name: "accessToken", value: "", path: "/", maxAge: 0 });
+  response.cookies.set({ name: "refreshToken", value: "", path: "/", maxAge: 0 });
+}

--- a/src/app/api/_lib/proxy.ts
+++ b/src/app/api/_lib/proxy.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+
+import { clearAuthCookies } from "./cookies";
+
+export function buildBackendUrl(path: string, searchParams: URLSearchParams): string {
+  const base = `${process.env.BACKEND_URL}/${process.env.TEAM_ID}/${path}`;
+  const query = searchParams.toString();
+  return query ? `${base}?${query}` : base;
+}
+
+export async function readRequestBody(request: Request): Promise<BodyInit | undefined> {
+  if (request.method === "GET" || request.method === "HEAD") return undefined;
+
+  const contentType = request.headers.get("Content-Type") ?? "";
+  const isMultipart = contentType.includes("multipart/form-data");
+
+  return isMultipart
+    ? request.blob()
+    : JSON.stringify(await request.json().catch(() => ({})));
+}
+
+export async function callBackend(
+  url: string,
+  method: string,
+  accessToken: string | undefined,
+  body: BodyInit | undefined,
+  contentType: string
+): Promise<Response> {
+  const isMultipart = contentType.includes("multipart/form-data");
+
+  return fetch(url, {
+    method,
+    headers: {
+      "Content-Type": isMultipart ? contentType : "application/json",
+      ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+    },
+    body,
+    cache: "no-store",
+  });
+}
+
+export function buildProxyResponse(backendResponse: Response): NextResponse {
+  return new NextResponse(backendResponse.body, {
+    status: backendResponse.status,
+    headers: {
+      "Content-Type": backendResponse.headers.get("Content-Type") ?? "application/json",
+    },
+  });
+}
+
+export async function attemptTokenRefresh(refreshToken: string): Promise<string | null> {
+  const refreshUrl = `${process.env.BACKEND_URL}/${process.env.TEAM_ID}/auth/refresh-token`;
+
+  try {
+    const response = await fetch(refreshUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+      cache: "no-store",
+    });
+
+    if (!response.ok) return null;
+
+    const data = (await response.json()) as { accessToken?: string };
+    return data.accessToken ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function buildUnauthorizedResponse(): NextResponse {
+  const response = NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  clearAuthCookies(response);
+  return response;
+}

--- a/src/app/api/auth/[...auth]/route.ts
+++ b/src/app/api/auth/[...auth]/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { setAccessTokenCookie, setRefreshTokenCookie } from "../../_lib/cookies";
+import { buildBackendUrl, callBackend, buildProxyResponse } from "../../_lib/proxy";
+
+interface AuthPayload {
+  accessToken?: string;
+  refreshToken?: string;
+  [key: string]: unknown;
+}
+
+async function handler(
+  request: NextRequest,
+  context: { params: Promise<{ auth: string[] }> }
+): Promise<NextResponse> {
+  const { auth } = await context.params;
+  const path = `auth/${auth.join("/")}`;
+  const backendUrl = buildBackendUrl(path, request.nextUrl.searchParams);
+  const contentType = request.headers.get("Content-Type") ?? "";
+  const body = JSON.stringify(await request.json().catch(() => ({})));
+
+  const backendResponse = await callBackend(backendUrl, request.method, undefined, body, contentType);
+
+  if (!backendResponse.ok) {
+    return buildProxyResponse(backendResponse);
+  }
+
+  const payload = (await backendResponse.json()) as AuthPayload;
+  const { accessToken, refreshToken, ...rest } = payload;
+
+  const response = NextResponse.json(rest, { status: backendResponse.status });
+
+  if (accessToken) setAccessTokenCookie(response, accessToken);
+  if (refreshToken) setRefreshTokenCookie(response, refreshToken);
+
+  return response;
+}
+
+export const POST = handler;

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+import { clearAuthCookies } from "../../_lib/cookies";
+
+export function POST(): NextResponse {
+  const response = NextResponse.json({ success: true });
+  clearAuthCookies(response);
+  return response;
+}


### PR DESCRIPTION
## ✏️ 작업 내용

- `src/app/api/_lib/cookies.ts` 추출 — 쿠키 헬퍼 (set/clear), `COOKIE_BASE` 객체로 중복 옵션 제거
- `src/app/api/_lib/proxy.ts` 추출 — `callBackend`, `buildBackendUrl`, `buildProxyResponse`, `readRequestBody`, `attemptTokenRefresh`, `buildUnauthorizedResponse`
- `auth/logout/route.ts` 분리 — 백엔드 호출 없이 쿠키 삭제만 담당
- `auth/[...auth]/route.ts` 분리 — 토큰 → HttpOnly 쿠키 변환 전담
- `[...path]/route.ts` 단순화 — generic proxy + `withTokenRefresh()` 헬퍼로 중복 retry 로직 통합, `AUTH_TOKEN_ENDPOINTS` 분기 제거

## 🗨️ 논의 사항 (참고 사항)

기존 `[...path]/route.ts` 한 파일에 logout 처리, auth 쿠키 변환, users/me guard, token refresh retry, generic proxy 5가지 관심사가 혼재되어 있었고, retry 응답 구성 코드가 동일한 패턴으로 2번 중복 존재.

## 기대효과

- 각 파일이 단일 책임을 가져 변경 범위가 명확해짐
- 중복 retry 로직이 `withTokenRefresh()` 하나로 통합
- `[...path]/route.ts` 242줄 → 55줄

Closes #289