### PR TITLE
feat: 프로필 이미지 업로드 파일 타입·파일명 검증 추가

### DIFF
--- a/src/shared/api/uploadImage.ts
+++ b/src/shared/api/uploadImage.ts
@@ -3,9 +3,18 @@ import { apiClient } from "./client";
 // Only ASCII printable characters allowed — the backend rejects non-English filenames
 const ASCII_ONLY = /^[\x20-\x7E]+$/;
 
+const ALLOWED_IMAGE_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+  "image/svg+xml",
+]);
+
 export async function uploadImage(file: File): Promise<string> {
-  if (!file.type.startsWith("image/")) {
-    throw new Error("이미지 파일만 업로드할 수 있습니다.");
+  if (!ALLOWED_IMAGE_TYPES.has(file.type)) {
+    throw new Error("jpg, png, gif, webp 형식의 이미지만 업로드할 수 있습니다.");
   }
 
   if (!ASCII_ONLY.test(file.name)) {

--- a/src/shared/api/uploadImage.ts
+++ b/src/shared/api/uploadImage.ts
@@ -4,8 +4,12 @@ import { apiClient } from "./client";
 const ASCII_ONLY = /^[\x20-\x7E]+$/;
 
 export async function uploadImage(file: File): Promise<string> {
+  if (!file.type.startsWith("image/")) {
+    throw new Error("이미지 파일만 업로드할 수 있습니다.");
+  }
+
   if (!ASCII_ONLY.test(file.name)) {
-    throw new Error(`이미지 파일명은 영문만 사용할 수 있습니다: "${file.name}"`);
+    throw new Error("파일명은 영문만 사용할 수 있습니다.");
   }
 
   const formData = new FormData();


### PR DESCRIPTION
## ✏️ 작업 내용

`src/shared/api/uploadImage.ts`에 업로드 전 검증 추가

1. **이미지 파일 타입 검사** (`file.type.startsWith("image/")`)
   - 비이미지 파일 선택 시 즉시 에러: "이미지 파일만 업로드할 수 있습니다."
2. **영문 파일명 검사** (`ASCII_ONLY` 정규식) — 기존 구현 에러 메시지 정리
   - 한글 등 비ASCII 파일명 시 에러: "파일명은 영문만 사용할 수 있습니다."

에러는 컴포넌트의 기존 catch 블록(`error instanceof Error ? error.message : ...`)을 통해 화면에 표시됨.

## 🗨️ 논의 사항 (참고 사항)

`<input accept="image/*">`는 파일 선택창 UI 필터일 뿐 — 드래그앤드롭이나 개발자 도구로 우회 가능. 클라이언트 측 검증을 추가해도 서버에서도 거부되지만 사용자에게 즉각적인 피드백을 제공하기 위해 추가.

## 기대효과

- 비이미지 파일 선택 시 즉시 에러 메시지 표시 (업로드 시도 없이)
- 한글 파일명 선택 시 즉시 에러 메시지 표시

Closes #291