### PR TITLE
feat: 로그인 후 원래 페이지로 리다이렉트 (#293)

### DIFF
--- a/src/app/oauth/callback/kakao/page.tsx
+++ b/src/app/oauth/callback/kakao/page.tsx
@@ -8,6 +8,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { signInKakao } from "@/entities/user";
+import { getSafeRedirect, SESSION_REDIRECT_KEY } from "@/shared/lib";
 
 function KakaoCallbackHandler(): null {
   const router = useRouter();
@@ -26,10 +27,9 @@ function KakaoCallbackHandler(): null {
     signInKakao({ token: code, redirectUri })
       .then(({ user }) => {
         queryClient.setQueryData(["me"], user);
-        const savedRedirect = sessionStorage.getItem("loginRedirect");
-        sessionStorage.removeItem("loginRedirect");
-        const destination = savedRedirect?.startsWith("/") ? savedRedirect : "/epigrams";
-        router.replace(destination);
+        const savedRedirect = sessionStorage.getItem(SESSION_REDIRECT_KEY);
+        sessionStorage.removeItem(SESSION_REDIRECT_KEY);
+        router.replace(getSafeRedirect(savedRedirect));
       })
       .catch(() => router.replace("/login"));
   }, [router, searchParams, queryClient]);

--- a/src/app/oauth/callback/kakao/page.tsx
+++ b/src/app/oauth/callback/kakao/page.tsx
@@ -26,7 +26,10 @@ function KakaoCallbackHandler(): null {
     signInKakao({ token: code, redirectUri })
       .then(({ user }) => {
         queryClient.setQueryData(["me"], user);
-        router.replace("/epigrams");
+        const savedRedirect = sessionStorage.getItem("loginRedirect");
+        sessionStorage.removeItem("loginRedirect");
+        const destination = savedRedirect?.startsWith("/") ? savedRedirect : "/epigrams";
+        router.replace(destination);
       })
       .catch(() => router.replace("/login"));
   }, [router, searchParams, queryClient]);

--- a/src/features/auth/ui/GuestLoginButton.tsx
+++ b/src/features/auth/ui/GuestLoginButton.tsx
@@ -2,7 +2,7 @@
 
 import { type ReactElement, useState } from "react";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -16,6 +16,7 @@ const GUEST_CREDENTIALS = {
 
 export function GuestLoginButton(): ReactElement {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -26,7 +27,8 @@ export function GuestLoginButton(): ReactElement {
     try {
       const { user } = await signIn(GUEST_CREDENTIALS);
       queryClient.setQueryData(["me"], user);
-      router.push("/epigrams");
+      const redirect = searchParams.get("redirect");
+      router.push(redirect?.startsWith("/") ? redirect : "/epigrams");
     } catch {
       setError("게스트 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.");
     } finally {

--- a/src/features/auth/ui/GuestLoginButton.tsx
+++ b/src/features/auth/ui/GuestLoginButton.tsx
@@ -7,6 +7,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { signIn } from "@/entities/user";
+import { getSafeRedirect } from "@/shared/lib";
 import { Button } from "@/shared/ui/Button";
 
 const GUEST_CREDENTIALS = {
@@ -27,8 +28,7 @@ export function GuestLoginButton(): ReactElement {
     try {
       const { user } = await signIn(GUEST_CREDENTIALS);
       queryClient.setQueryData(["me"], user);
-      const redirect = searchParams.get("redirect");
-      router.push(redirect?.startsWith("/") ? redirect : "/epigrams");
+      router.push(getSafeRedirect(searchParams.get("redirect")));
     } catch {
       setError("게스트 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.");
     } finally {

--- a/src/features/auth/ui/KakaoLoginButton.tsx
+++ b/src/features/auth/ui/KakaoLoginButton.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type { ReactElement } from "react";
+
+import { useSearchParams } from "next/navigation";
+
+interface KakaoLoginButtonProps {
+  kakaoOauthUrl: string;
+}
+
+export function KakaoLoginButton({ kakaoOauthUrl }: KakaoLoginButtonProps): ReactElement {
+  const searchParams = useSearchParams();
+
+  function handleClick(): void {
+    const redirect = searchParams.get("redirect");
+    if (redirect?.startsWith("/")) {
+      sessionStorage.setItem("loginRedirect", redirect);
+    }
+  }
+
+  return (
+    <a
+      href={kakaoOauthUrl}
+      aria-label="카카오로 로그인"
+      onClick={handleClick}
+      className="flex h-10 w-10 items-center justify-center rounded-full transition-all duration-150 hover:scale-110 hover:opacity-90 active:scale-95"
+      style={{ backgroundColor: "#FEE500" }}
+    >
+      <span className="text-sm font-bold leading-none text-[#191919]">K</span>
+    </a>
+  );
+}

--- a/src/features/auth/ui/KakaoLoginButton.tsx
+++ b/src/features/auth/ui/KakaoLoginButton.tsx
@@ -4,6 +4,8 @@ import type { ReactElement } from "react";
 
 import { useSearchParams } from "next/navigation";
 
+import { SESSION_REDIRECT_KEY } from "@/shared/lib";
+
 interface KakaoLoginButtonProps {
   kakaoOauthUrl: string;
 }
@@ -14,7 +16,7 @@ export function KakaoLoginButton({ kakaoOauthUrl }: KakaoLoginButtonProps): Reac
   function handleClick(): void {
     const redirect = searchParams.get("redirect");
     if (redirect?.startsWith("/")) {
-      sessionStorage.setItem("loginRedirect", redirect);
+      sessionStorage.setItem(SESSION_REDIRECT_KEY, redirect);
     }
   }
 

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -9,6 +9,7 @@ import { useForm } from "react-hook-form";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { signIn } from "@/entities/user";
+import { getSafeRedirect } from "@/shared/lib";
 import { Button } from "@/shared/ui/Button";
 import { Input } from "@/shared/ui/Input";
 
@@ -33,8 +34,7 @@ export function LoginForm(): ReactElement {
     try {
       const { user } = await signIn(data);
       queryClient.setQueryData(["me"], user);
-      const redirect = searchParams.get("redirect");
-      router.push(redirect?.startsWith("/") ? redirect : "/epigrams");
+      router.push(getSafeRedirect(searchParams.get("redirect")));
     } catch {
       const message = "이메일 혹은 비밀번호를 확인해주세요.";
       setError("email", { message });

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -3,7 +3,7 @@
 import type { ReactElement } from "react";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
 
 import { useQueryClient } from "@tanstack/react-query";
@@ -16,6 +16,7 @@ import { loginSchema, type LoginFormValues } from "../model/loginSchema";
 
 export function LoginForm(): ReactElement {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const queryClient = useQueryClient();
 
   const {
@@ -32,7 +33,8 @@ export function LoginForm(): ReactElement {
     try {
       const { user } = await signIn(data);
       queryClient.setQueryData(["me"], user);
-      router.push("/");
+      const redirect = searchParams.get("redirect");
+      router.push(redirect?.startsWith("/") ? redirect : "/epigrams");
     } catch {
       const message = "이메일 혹은 비밀번호를 확인해주세요.";
       setError("email", { message });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,7 +18,9 @@ export function middleware(request: NextRequest): NextResponse | undefined {
   const isLoggedIn = request.cookies.has("accessToken") || request.cookies.has("refreshToken");
 
   if (isProtectedPath(pathname) && !isLoggedIn) {
-    return NextResponse.redirect(new URL("/login", request.url));
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("redirect", pathname);
+    return NextResponse.redirect(loginUrl);
   }
 
   if (AUTH_ONLY_PATHS.some((p) => pathname.startsWith(p)) && isLoggedIn) {

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,3 +1,4 @@
 export { cn } from "./cn";
 export { formatDate, formatRelativeTime } from "./date";
 export { copyToClipboard } from "./clipboard";
+export { getSafeRedirect, SESSION_REDIRECT_KEY, DEFAULT_REDIRECT_PATH } from "./redirect";

--- a/src/shared/lib/redirect.ts
+++ b/src/shared/lib/redirect.ts
@@ -1,0 +1,7 @@
+export const SESSION_REDIRECT_KEY = "loginRedirect";
+export const DEFAULT_REDIRECT_PATH = "/epigrams";
+
+/** open redirect 방지: / 로 시작하는 경로만 허용 */
+export function getSafeRedirect(redirect: string | null | undefined): string {
+  return redirect?.startsWith("/") ? redirect : DEFAULT_REDIRECT_PATH;
+}

--- a/src/views/login/ui/LoginPage.tsx
+++ b/src/views/login/ui/LoginPage.tsx
@@ -1,9 +1,12 @@
 import type { ReactElement, ReactNode } from "react";
 
+import { Suspense } from "react";
+
 import Link from "next/link";
 
 import { AuthLeftPanel } from "@/features/auth/ui/AuthLeftPanel";
 import { GuestLoginButton } from "@/features/auth/ui/GuestLoginButton";
+import { KakaoLoginButton } from "@/features/auth/ui/KakaoLoginButton";
 import { LoginForm } from "@/features/auth/ui/LoginForm";
 import { EpigramLogo } from "@/shared/ui/EpigramLogo";
 
@@ -21,8 +24,10 @@ export function LoginPage(): ReactElement {
           </div>
           <div className="flex flex-col gap-[50px]">
             <div className="flex flex-col gap-[10px]">
-              <LoginForm />
-              <GuestLoginButton />
+              <Suspense>
+                <LoginForm />
+                <GuestLoginButton />
+              </Suspense>
               <div className="flex items-center gap-2">
                 <span className="text-sm text-blue-400">회원이 아니신가요?</span>
                 <Link href="/signup" className="text-sm font-medium text-black-600 hover:underline">
@@ -66,9 +71,9 @@ function SocialLoginSection({ kakaoOauthUrl }: SocialLoginSectionProps): ReactEl
         >
           <span className="text-sm font-bold leading-none text-[#4285F4]">G</span>
         </SocialIconButton>
-        <SocialIconButton href={kakaoOauthUrl} label="카카오로 로그인" bgColor="#FEE500">
-          <span className="text-sm font-bold leading-none text-[#191919]">K</span>
-        </SocialIconButton>
+        <Suspense>
+          <KakaoLoginButton kakaoOauthUrl={kakaoOauthUrl} />
+        </Suspense>
       </div>
     </div>
   );


### PR DESCRIPTION
## ✏️ 작업 내용

- 미들웨어: 보호 경로 접근 시 `/login?redirect=<pathname>` 으로 리다이렉트
- `LoginForm`, `GuestLoginButton`: `useSearchParams()`로 `redirect` 파라미터 읽어 로그인 후 해당 경로로 이동
- `KakaoLoginButton` (신규): Kakao OAuth 리다이렉트 전 `sessionStorage`에 redirect URL 저장
- `KakaoCallbackPage`: `sessionStorage`의 redirect URL 복원 후 이동
- `LoginPage`: `useSearchParams()` 사용 컴포넌트를 `<Suspense>`로 래핑
- `shared/lib/redirect.ts` 추출: `getSafeRedirect()`, `SESSION_REDIRECT_KEY`, `DEFAULT_REDIRECT_PATH` 공통 유틸
- open redirect 방지: `redirect` 값이 `/` 로 시작하는지 검증

## 🗨️ 논의 사항 (참고 사항)

Kakao OAuth는 외부 서버를 거쳐 돌아오기 때문에 URL 쿼리 파라미터를 유지할 수 없어 `sessionStorage`를 사용했습니다.

## 기대효과

이 PR이 머지되면 닫히는 이슈 번호를 적어주세요.
Closes #293