### PR TITLE
feat: 최근 검색어 개별 삭제 버튼 제거 및 칩 전체 클릭으로 검색 실행 (#297)

### DIFF
--- a/src/features/epigram-search/model/useRecentSearches.ts
+++ b/src/features/epigram-search/model/useRecentSearches.ts
@@ -20,7 +20,6 @@ function saveToStorage(searches: string[]): void {
 interface UseRecentSearchesResult {
   recentSearches: string[];
   addRecentSearch: (keyword: string) => void;
-  removeRecentSearch: (keyword: string) => void;
   clearAllRecentSearches: () => void;
 }
 
@@ -47,18 +46,10 @@ export function useRecentSearches(): UseRecentSearchesResult {
     });
   }, []);
 
-  const removeRecentSearch = useCallback((keyword: string) => {
-    setRecentSearches((prev) => {
-      const updated = prev.filter((k) => k !== keyword);
-      saveToStorage(updated);
-      return updated;
-    });
-  }, []);
-
   const clearAllRecentSearches = useCallback(() => {
     saveToStorage([]);
     setRecentSearches([]);
   }, []);
 
-  return { recentSearches, addRecentSearch, removeRecentSearch, clearAllRecentSearches };
+  return { recentSearches, addRecentSearch, clearAllRecentSearches };
 }

--- a/src/features/epigram-search/model/useSearch.ts
+++ b/src/features/epigram-search/model/useSearch.ts
@@ -12,7 +12,6 @@ interface UseSearchResult {
   recentSearches: string[];
   handleInputChange: (value: string) => void;
   handleSearch: (keyword: string) => void;
-  removeRecentSearch: (keyword: string) => void;
   clearAllRecentSearches: () => void;
 }
 
@@ -25,8 +24,7 @@ export function useSearch(): UseSearchResult {
 
   const [inputValue, setInputValue] = useState(activeKeyword);
 
-  const { recentSearches, addRecentSearch, removeRecentSearch, clearAllRecentSearches } =
-    useRecentSearches();
+  const { recentSearches, addRecentSearch, clearAllRecentSearches } = useRecentSearches();
 
   function handleInputChange(value: string): void {
     setInputValue(value);
@@ -50,7 +48,6 @@ export function useSearch(): UseSearchResult {
     recentSearches,
     handleInputChange,
     handleSearch,
-    removeRecentSearch,
     clearAllRecentSearches,
   };
 }

--- a/src/features/epigram-search/ui/SearchBar.tsx
+++ b/src/features/epigram-search/ui/SearchBar.tsx
@@ -2,43 +2,30 @@
 
 import { type KeyboardEvent, type ReactElement } from "react";
 
-import { Search, X } from "lucide-react";
+import { Search } from "lucide-react";
 
 interface SearchBarProps {
   inputValue: string;
   recentSearches: string[];
   onInputChange: (value: string) => void;
   onSearch: (keyword: string) => void;
-  onRemoveRecent: (keyword: string) => void;
   onClearAllRecent: () => void;
 }
 
 interface RecentSearchChipProps {
   keyword: string;
   onSelect: (keyword: string) => void;
-  onRemove: (keyword: string) => void;
 }
 
-function RecentSearchChip({ keyword, onSelect, onRemove }: RecentSearchChipProps): ReactElement {
+function RecentSearchChip({ keyword, onSelect }: RecentSearchChipProps): ReactElement {
   return (
-    <li className="group flex items-center gap-0.5 rounded-full bg-blue-200/60 px-3 py-1.5 text-sm text-black-600 transition-all duration-150 hover:bg-blue-200 hover:text-black-900 pc:px-4 pc:py-2 pc:text-sm">
+    <li>
       <button
         type="button"
         onClick={() => onSelect(keyword)}
-        className="max-w-[120px] truncate leading-none pc:max-w-[160px]"
+        className="rounded-full bg-blue-200/60 px-3 py-1.5 text-sm text-black-600 transition-all duration-150 hover:bg-blue-200 hover:text-black-900 pc:px-4 pc:py-2 pc:text-sm"
       >
         {keyword}
-      </button>
-      <button
-        type="button"
-        aria-label={`"${keyword}" 검색어 삭제`}
-        onClick={(e) => {
-          e.stopPropagation();
-          onRemove(keyword);
-        }}
-        className="ml-1 flex items-center text-blue-400 opacity-60 transition-opacity duration-150 hover:text-black-500 hover:opacity-100 group-hover:opacity-100"
-      >
-        <X size={11} strokeWidth={2.5} />
       </button>
     </li>
   );
@@ -49,7 +36,6 @@ export function SearchBar({
   recentSearches,
   onInputChange,
   onSearch,
-  onRemoveRecent,
   onClearAllRecent,
 }: SearchBarProps): ReactElement {
   function handleKeyDown(e: KeyboardEvent<HTMLInputElement>): void {
@@ -94,12 +80,7 @@ export function SearchBar({
           </div>
           <ul className="flex flex-wrap gap-2 pc:gap-2.5">
             {recentSearches.map((keyword) => (
-              <RecentSearchChip
-                key={keyword}
-                keyword={keyword}
-                onSelect={onSearch}
-                onRemove={onRemoveRecent}
-              />
+              <RecentSearchChip key={keyword} keyword={keyword} onSelect={onSearch} />
             ))}
           </ul>
         </div>

--- a/src/views/search/ui/SearchPage.tsx
+++ b/src/views/search/ui/SearchPage.tsx
@@ -185,7 +185,6 @@ export function SearchPage(): ReactElement {
     recentSearches,
     handleInputChange,
     handleSearch,
-    removeRecentSearch,
     clearAllRecentSearches,
   } = useSearch();
 
@@ -202,7 +201,6 @@ export function SearchPage(): ReactElement {
           recentSearches={recentSearches}
           onInputChange={handleInputChange}
           onSearch={handleSearch}
-          onRemoveRecent={removeRecentSearch}
           onClearAllRecent={clearAllRecentSearches}
         />
 


### PR DESCRIPTION
## ✏️ 작업 내용

- 최근 검색어 칩에서 개별 X(삭제) 버튼 제거
- 칩 전체를 단일 버튼으로 변경하여 어디든 클릭하면 해당 검색어로 검색 실행
- `useRecentSearches` / `useSearch` / `SearchBar` / `SearchPage` 에서 `removeRecentSearch` 관련 코드 일괄 제거
- 전체 지우기 버튼(`모두 지우기`)은 유지

## 🗨️ 논의 사항 (참고 사항)

없음

## 기대효과

이 PR이 머지되면 닫히는 이슈 번호를 적어주세요.

Closes #297