### PR TITLE
perf: 댓글·에피그램 카드 React.memo 적용으로 불필요한 리렌더링 방지 (#299)

### DIFF
--- a/src/entities/epigram/ui/EpigramListCard.tsx
+++ b/src/entities/epigram/ui/EpigramListCard.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import { memo, type ReactElement } from "react";
 
 import Link from "next/link";
 
@@ -8,7 +8,7 @@ interface EpigramListCardProps {
   epigram: Epigram;
 }
 
-export function EpigramListCard({ epigram }: EpigramListCardProps): ReactElement {
+function EpigramListCardBase({ epigram }: EpigramListCardProps): ReactElement {
   return (
     <div className="flex min-w-0 flex-col items-end gap-2">
       <Link
@@ -51,3 +51,5 @@ export function EpigramListCard({ epigram }: EpigramListCardProps): ReactElement
     </div>
   );
 }
+
+export const EpigramListCard = memo(EpigramListCardBase);

--- a/src/features/epigram-search/ui/SearchResultItem.tsx
+++ b/src/features/epigram-search/ui/SearchResultItem.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactElement, type ReactNode, useMemo } from "react";
+import { memo, type ReactElement, type ReactNode, useMemo } from "react";
 
 import Link from "next/link";
 
@@ -63,7 +63,7 @@ function TagList({ tags, keyword }: TagListProps): ReactElement | null {
   );
 }
 
-export function SearchResultItem({ epigram, keyword }: SearchResultItemProps): ReactElement {
+function SearchResultItemBase({ epigram, keyword }: SearchResultItemProps): ReactElement {
   const authorLabel = epigram.referenceTitle
     ? `${epigram.author} 《${epigram.referenceTitle}》`
     : epigram.author;
@@ -86,3 +86,5 @@ export function SearchResultItem({ epigram, keyword }: SearchResultItemProps): R
     </Link>
   );
 }
+
+export const SearchResultItem = memo(SearchResultItemBase);

--- a/src/widgets/comment-section/ui/CommentSection.tsx
+++ b/src/widgets/comment-section/ui/CommentSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { memo, useState } from "react";
 import type { ReactElement } from "react";
 
 import { MessageCircle, MoreVertical, Pencil, Trash2 } from "lucide-react";
@@ -30,7 +30,7 @@ interface CommentItemProps {
   currentUserId: number | undefined;
 }
 
-function CommentItem({ comment, epigramId, currentUserId }: CommentItemProps): ReactElement {
+function CommentItemBase({ comment, epigramId, currentUserId }: CommentItemProps): ReactElement {
   const [isEditing, setIsEditing] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { open } = useModal();
@@ -125,6 +125,8 @@ function CommentItem({ comment, epigramId, currentUserId }: CommentItemProps): R
     </li>
   );
 }
+
+const CommentItem = memo(CommentItemBase);
 
 function CommentSkeleton(): ReactElement {
   return (

--- a/src/widgets/comment-section/ui/RecentComments.tsx
+++ b/src/widgets/comment-section/ui/RecentComments.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactElement } from "react";
+import { memo, type ReactElement } from "react";
 
 import { ChevronDown } from "lucide-react";
 
@@ -18,7 +18,7 @@ interface CommentItemProps {
   comment: Comment;
 }
 
-function CommentItem({ comment }: CommentItemProps): ReactElement {
+function CommentItemBase({ comment }: CommentItemProps): ReactElement {
   const { open } = useModal();
 
   function handleProfileClick(): void {
@@ -50,6 +50,8 @@ function CommentItem({ comment }: CommentItemProps): ReactElement {
     </li>
   );
 }
+
+const CommentItem = memo(CommentItemBase);
 
 interface LoadMoreButtonProps {
   isFetchingNextPage: boolean;


### PR DESCRIPTION
## ✏️ 작업 내용

무한 스크롤 목록에서 `isFetchingNextPage`, `hasNextPage` 등 부모 상태가 바뀔 때 모든 아이템이 불필요하게 리렌더링되는 문제를 `React.memo`로 해결한다.

**적용 대상 (4개 컴포넌트)**

| 컴포넌트 | 파일 | 효과 |
|---|---|---|
| `EpigramListCard` | `entities/epigram/ui/EpigramListCard.tsx` | 피드·검색 목록에서 더보기 로딩 중 기존 카드 재렌더 방지 |
| `CommentItem` | `widgets/comment-section/ui/CommentSection.tsx` | 댓글 무한 스크롤에서 기존 댓글 재렌더 방지 |
| `CommentItem` | `widgets/comment-section/ui/RecentComments.tsx` | 최신 댓글 목록에서 기존 댓글 재렌더 방지 |
| `SearchResultItem` | `features/epigram-search/ui/SearchResultItem.tsx` | 검색 결과 추가 로드 중 기존 항목 재렌더 방지 |

**구현 방식**
- `function` 키워드 선언을 유지하고 `memo(ComponentBase)` 패턴으로 래핑
- 공개 export 이름(`EpigramListCard`, `SearchResultItem`) 변경 없음

## 🗨️ 논의 사항 (참고 사항)

없음

## 기대효과

Closes #299