### PR TITLE
chore: .claude/*.lock을 .gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ next-env.d.ts
 
 # Claude Code hooks
 .claude/*.local.md
+.claude/*.lock


### PR DESCRIPTION
## 작업 내용
Claude Code 런타임 락 파일(`.claude/scheduled_tasks.lock` 등)이 매번 `git status`에 untracked로 노출되어 작업 흐름을 흐리던 문제를 정리한다. 사용자별 로컬 아티팩트라 공유 대상이 아니다.

- `.gitignore`에 `.claude/*.lock` 패턴 추가

## 영향 범위
- `.gitignore`

Closes #301