### PR TITLE
fix: 라우트 보호 우회 및 로그인 후 redirect 미동작 (#303)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,6 +12,15 @@ function isProtectedPath(pathname: string): boolean {
 // 로그인 상태에서 접근하면 홈으로 리다이렉트
 const AUTH_ONLY_PATHS = ["/login", "/signup", "/oauth/signup/kakao"];
 
+// 미들웨어 리다이렉트 응답이 브라우저/Next 클라이언트 캐시에 남으면
+// 로그인 후에도 보호 경로로 이동했을 때 캐시된 "→ /login" 응답이 재사용되어
+// 사용자가 다시 로그인 페이지로 튕긴다. no-store로 캐시 자체를 차단한다.
+function redirectWithoutCache(url: URL): NextResponse {
+  const response = NextResponse.redirect(url);
+  response.headers.set("Cache-Control", "no-store");
+  return response;
+}
+
 export function middleware(request: NextRequest): NextResponse | undefined {
   const { pathname } = request.nextUrl;
   // accessToken이 없어도 refreshToken이 있으면 BFF에서 갱신 가능하므로 통과
@@ -20,20 +29,24 @@ export function middleware(request: NextRequest): NextResponse | undefined {
   if (isProtectedPath(pathname) && !isLoggedIn) {
     const loginUrl = new URL("/login", request.url);
     loginUrl.searchParams.set("redirect", pathname);
-    return NextResponse.redirect(loginUrl);
+    return redirectWithoutCache(loginUrl);
   }
 
   if (AUTH_ONLY_PATHS.some((p) => pathname.startsWith(p)) && isLoggedIn) {
-    return NextResponse.redirect(new URL("/epigrams", request.url));
+    return redirectWithoutCache(new URL("/epigrams", request.url));
   }
 }
 
 export const config = {
   matcher: [
-    // 보호 경로: /epigrams/[id] 이하, /addepigram, /mypage
+    // 보호 경로: /epigrams/[id] 이하, /addepigram(+하위), /mypage(+하위)
+    // /addepigram, /mypage 는 정확 매칭과 하위 경로를 모두 등록 — path-to-regexp의
+    // ":path*"는 "/addepigram/..." 형태만 매칭하고 "/addepigram" 자체는 빠진다.
     "/epigrams/:path+",
-    "/addepigram/:path*",
-    "/mypage/:path*",
+    "/addepigram",
+    "/addepigram/:path+",
+    "/mypage",
+    "/mypage/:path+",
     // 로그인 전용: 이미 로그인 시 홈으로
     "/login",
     "/signup",


### PR DESCRIPTION
## ✏️ 작업 내용

- `middleware.ts` matcher에 `/addepigram`, `/mypage` 정확 매칭 추가
  - 기존 `/addepigram/:path*`은 path-to-regexp 특성상 `/addepigram/...`만 매칭하고 `/addepigram` 자체는 빠져 비로그인 접근이 통과되던 문제 해결
- `redirectWithoutCache()` 헬퍼 추가하여 미들웨어 redirect 응답에 `Cache-Control: no-store` 적용
  - 보호 경로 → `/login`, 로그인 전용 경로 → `/epigrams` 두 케이스 모두 적용

## 🗨️ 논의 사항 (참고 사항)

- 로그인 후 원래 가려던 페이지로 이동하지 않던 현상은 브라우저/Next 클라이언트 캐시가 미들웨어 redirect 응답을 재사용한 것이 원인. 클라이언트 코드(`router.refresh() + router.push()`)는 그대로 두고 미들웨어 응답 헤더만 손봐 해결.

## 기대효과

- `/addepigram`(피드 추가) 페이지가 비로그인 상태에서 정상적으로 `/login`으로 차단됨
- 로그인 후 redirect 파라미터로 지정된 원래 경로로 정상 이동

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)
