### PR TITLE
chore: 로그인 페이지 SNS 로그인 카카오만 남기고 정리 (#309)

### DIFF
--- a/src/views/login/ui/LoginPage.tsx
+++ b/src/views/login/ui/LoginPage.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from "react";
+import type { ReactElement } from "react";
 
 import { Suspense } from "react";
 
@@ -56,52 +56,10 @@ function SocialLoginSection({ kakaoOauthUrl }: SocialLoginSectionProps): ReactEl
         <hr className="flex-1 border-line-200" />
       </div>
       <div className="flex justify-center gap-4">
-        <SocialIconButton
-          href="https://nid.naver.com/oauth2.0/authorize"
-          label="네이버로 로그인"
-          bgColor="#03C75A"
-        >
-          <span className="text-sm font-bold leading-none text-white">N</span>
-        </SocialIconButton>
-        <SocialIconButton
-          href="https://accounts.google.com/o/oauth2/v2/auth"
-          label="구글로 로그인"
-          bgColor="#ffffff"
-          className="border border-line-200"
-        >
-          <span className="text-sm font-bold leading-none text-[#4285F4]">G</span>
-        </SocialIconButton>
         <Suspense>
           <KakaoLoginButton kakaoOauthUrl={kakaoOauthUrl} />
         </Suspense>
       </div>
     </div>
-  );
-}
-
-interface SocialIconButtonProps {
-  href: string;
-  label: string;
-  bgColor: string;
-  className?: string;
-  children: ReactNode;
-}
-
-function SocialIconButton({
-  href,
-  label,
-  bgColor,
-  className = "",
-  children,
-}: SocialIconButtonProps): ReactElement {
-  return (
-    <a
-      href={href}
-      aria-label={label}
-      className={`flex h-10 w-10 items-center justify-center rounded-full transition-all duration-150 hover:scale-110 hover:opacity-90 active:scale-95 ${className}`}
-      style={{ backgroundColor: bgColor }}
-    >
-      {children}
-    </a>
   );
 }


### PR DESCRIPTION
## ✏️ 작업 내용

- `src/views/login/ui/LoginPage.tsx` 의 네이버 / 구글 SNS 로그인 아이콘 제거 (실제 백엔드·시안 모두 지원하지 않는 비활성 진입점)
- 사용처가 사라진 `SocialIconButton` 헬퍼 함수와 props interface 제거
- 더 이상 필요 없는 `ReactNode` import 정리
- 카카오 로그인 버튼만 남기고 SNS 영역의 구분선 / 라벨은 유지

## 🗨️ 논의 사항 (참고 사항)

- 시안에 네이버·구글 버튼이 없고 백엔드 OAuth 도 카카오만 지원하는 상태에서 동작하지 않는 버튼을 노출하면 사용자 혼선을 줄 수 있어 제거
- 차후 카카오 외 OAuth 가 추가되면 `SocialIconButton` 헬퍼는 다시 도입 가능한 수준의 단순한 컴포넌트라 지금 미리 둘 필요는 없다고 판단

## 기대효과

- 클릭해도 동작하지 않는 SNS 진입점이 사라져 사용자 경험이 정확해집니다.
- LoginPage 가 44 → 1 줄로 줄어들어 유지보수 부담도 감소합니다.

Closes #309