### PR TITLE
fix: 랜딩 앱 QR 팝오버에서 QR 이미지 배경 흰색으로 지정 (#315)

### DIFF
--- a/src/views/landing/ui/AppQrPopover.tsx
+++ b/src/views/landing/ui/AppQrPopover.tsx
@@ -76,7 +76,7 @@ export function AppQrPopover(): ReactElement {
               width={180}
               height={180}
               unoptimized
-              className="h-44 w-44"
+              className="h-44 w-44 bg-white"
             />
             <p className="text-center text-xs text-black-500">
               Expo Go 앱으로


### PR DESCRIPTION
## 요약

랜딩 페이지 "앱으로 받기" 버튼을 누르면 뜨는 QR 팝오버에서, QR PNG 자체가 투명 배경이라 모듈(검은 픽셀) 사이로 팝오버 뒤쪽 텍스트가 비치는 문제.

## 변경

`<Image>` 클래스에 `bg-white` 추가. 1줄.

## 검증

- `npm run lint` — 0 errors
- 단순 className 추가라 build 영향 없음

Closes #315
