### PR TITLE
fix: 랜딩 히어로 QR 팝오버가 scroll 힌트 아래로 가려지는 문제 수정 (#319)

### DIFF
--- a/src/views/landing/ui/LandingPage.tsx
+++ b/src/views/landing/ui/LandingPage.tsx
@@ -39,7 +39,7 @@ function HeroSection(): ReactElement {
         {"\u201C"}
       </span>
 
-      <div className="relative flex flex-col items-center gap-8 animate-fade-in-up">
+      <div className="relative z-10 flex flex-col items-center gap-8 animate-fade-in-up">
         <div className="flex flex-col gap-3">
           <h1 className="font-serif text-2xl font-normal leading-tight text-black-500 tablet:text-4xl desktop:text-5xl">
             나만 갖고 있기엔


### PR DESCRIPTION
## ✏️ 작업 내용

랜딩 페이지 히어로 섹션에서 `앱으로 받기` 버튼을 누르면 QR 팝오버 하단에 `scroll` 힌트 텍스트가 겹쳐 보이던 문제를 수정했습니다.

- `LandingPage.tsx`의 `animate-fade-in-up` 컨테이너 `<div>`에 `z-10`을 추가해 stacking 순서를 `scroll` 힌트보다 위로 올렸습니다.

## 🗨️ 논의 사항 (참고 사항)

- 처음에는 팝오버에 `z-100` 클래스를 추가하는 방향으로 시도했지만 두 가지 이유로 효과가 없었습니다.
  1. Tailwind 기본 z-index 유틸리티는 `z-0 / z-10 / z-20 / z-30 / z-40 / z-50 / z-auto`만 제공하므로 `z-100`은 무시됩니다 (임의값을 쓰려면 `z-[100]` 문법 필요).
  2. 더 근본적으로, `animate-fade-in-up`이 걸린 부모 컨테이너가 transform + `both` fill-mode로 새 stacking context를 만들기 때문에, 팝오버 내부의 z-index는 부모 밖의 `scroll` 힌트와 경쟁하지 못합니다. 부모 컨테이너 자체의 z-index가 `auto`라 DOM 순서가 뒤인 `scroll`이 이기는 구조였습니다.
- 따라서 팝오버의 z값이 아닌 **부모 컨테이너의 z-index를 올리는 것**이 루트 원인 해결입니다.

## 기대효과

- 랜딩 히어로에서 QR 팝오버가 항상 `scroll` 힌트 위에 렌더링됩니다.
- 무효한 Tailwind 클래스로 인한 혼선이 제거됩니다.

Closes #319
