### PR TITLE
fix: README.md 포맷 수정으로 CI format check 복구 (#323)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
 
 <img width="200" height="200" alt="image" src="https://github.com/user-attachments/assets/ea43e8d6-d71a-46e1-8701-3e1e9111f0fa" />
 
-
 <br />
 
 <br />


### PR DESCRIPTION
## 문제
- `0d1d714 Update README.md` 이후 main CI의 **Format check** 단계가 계속 실패.
- 원인은 README.md 말미의 불필요한 공백 줄. 이후 머지된 PR들(#322 등)도 동일 원인으로 연쇄 실패.

## 변경 내용
- `npx prettier --write README.md` 적용 (trailing blank line 1줄 제거)

## 테스트
- `npx prettier --check README.md` → All matched files use Prettier code style
- `npm run lint`, `npm run build`은 머지 전 CI에서 검증

Closes #323