### PR TITLE
fix: 에피그램 삭제 시 마이페이지 댓글 캐시 무효화 (#329)

### DIFF
--- a/src/features/epigram-delete/model/useEpigramDelete.ts
+++ b/src/features/epigram-delete/model/useEpigramDelete.ts
@@ -12,7 +12,7 @@ interface UseEpigramDeleteReturn {
   isDeleting: boolean;
 }
 
-export function useEpigramDelete(epigramId: number, userId?: number): UseEpigramDeleteReturn {
+export function useEpigramDelete(epigramId: number): UseEpigramDeleteReturn {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { open } = useModal();
@@ -20,12 +20,10 @@ export function useEpigramDelete(epigramId: number, userId?: number): UseEpigram
   const { mutate, isPending: isDeleting } = useMutation({
     mutationFn: () => apiClient.delete(`/api/epigrams/${epigramId}`).then((res) => res.data),
     onSuccess: () => {
-      // fire-and-forget: await 시 ["epigrams", epigramId] active 쿼리가 refetch되어 404가 나면서 navigation이 막힌다.
-      // 에피그램 삭제 시 백엔드에서 댓글도 함께 삭제되므로 작성자의 댓글 캐시도 함께 무효화한다.
       queryClient.invalidateQueries({ queryKey: ["epigrams"] });
-      if (userId !== undefined) {
-        queryClient.invalidateQueries({ queryKey: ["users", userId, "comments"] });
-      }
+      queryClient.invalidateQueries({
+        predicate: (query) => query.queryKey.includes("comments"),
+      });
       router.push("/epigrams");
     },
   });

--- a/src/features/epigram-delete/model/useEpigramDelete.ts
+++ b/src/features/epigram-delete/model/useEpigramDelete.ts
@@ -19,15 +19,13 @@ export function useEpigramDelete(epigramId: number, userId?: number): UseEpigram
 
   const { mutate, isPending: isDeleting } = useMutation({
     mutationFn: () => apiClient.delete(`/api/epigrams/${epigramId}`).then((res) => res.data),
-    onSuccess: async () => {
-      // 에피그램 삭제 시 백엔드에서 댓글도 함께 삭제되므로, 작성자의 댓글 캐시도 무효화한다.
-      const invalidations = [queryClient.invalidateQueries({ queryKey: ["epigrams"] })];
+    onSuccess: () => {
+      // fire-and-forget: await 시 ["epigrams", epigramId] active 쿼리가 refetch되어 404가 나면서 navigation이 막힌다.
+      // 에피그램 삭제 시 백엔드에서 댓글도 함께 삭제되므로 작성자의 댓글 캐시도 함께 무효화한다.
+      queryClient.invalidateQueries({ queryKey: ["epigrams"] });
       if (userId !== undefined) {
-        invalidations.push(
-          queryClient.invalidateQueries({ queryKey: ["users", userId, "comments"] })
-        );
+        queryClient.invalidateQueries({ queryKey: ["users", userId, "comments"] });
       }
-      await Promise.all(invalidations);
       router.push("/epigrams");
     },
   });

--- a/src/features/epigram-delete/model/useEpigramDelete.ts
+++ b/src/features/epigram-delete/model/useEpigramDelete.ts
@@ -12,15 +12,22 @@ interface UseEpigramDeleteReturn {
   isDeleting: boolean;
 }
 
-export function useEpigramDelete(epigramId: number): UseEpigramDeleteReturn {
+export function useEpigramDelete(epigramId: number, userId?: number): UseEpigramDeleteReturn {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { open } = useModal();
 
   const { mutate, isPending: isDeleting } = useMutation({
     mutationFn: () => apiClient.delete(`/api/epigrams/${epigramId}`).then((res) => res.data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["epigrams"] });
+    onSuccess: async () => {
+      // 에피그램 삭제 시 백엔드에서 댓글도 함께 삭제되므로, 작성자의 댓글 캐시도 무효화한다.
+      const invalidations = [queryClient.invalidateQueries({ queryKey: ["epigrams"] })];
+      if (userId !== undefined) {
+        invalidations.push(
+          queryClient.invalidateQueries({ queryKey: ["users", userId, "comments"] })
+        );
+      }
+      await Promise.all(invalidations);
       router.push("/epigrams");
     },
   });

--- a/src/views/epigram-detail/ui/EpigramDetailPage.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailPage.tsx
@@ -93,7 +93,7 @@ export function EpigramDetailPage({ epigramId }: EpigramDetailPageProps): ReactE
 
   const { data: epigram, isLoading: isEpigramLoading } = useEpigramDetail(epigramId);
   const { user: me, isLoading: isMeLoading } = useMe();
-  const { handleDeleteClick } = useEpigramDelete(epigramId);
+  const { handleDeleteClick } = useEpigramDelete(epigramId, me?.id);
 
   const isLoading = isEpigramLoading || isMeLoading;
   const isOwner = !isLoading && epigram !== undefined && me !== null && epigram.writerId === me.id;

--- a/src/views/epigram-detail/ui/EpigramDetailPage.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailPage.tsx
@@ -93,7 +93,7 @@ export function EpigramDetailPage({ epigramId }: EpigramDetailPageProps): ReactE
 
   const { data: epigram, isLoading: isEpigramLoading } = useEpigramDetail(epigramId);
   const { user: me, isLoading: isMeLoading } = useMe();
-  const { handleDeleteClick } = useEpigramDelete(epigramId, me?.id);
+  const { handleDeleteClick } = useEpigramDelete(epigramId);
 
   const isLoading = isEpigramLoading || isMeLoading;
   const isOwner = !isLoading && epigram !== undefined && me !== null && epigram.writerId === me.id;


### PR DESCRIPTION
## ✏️ 작업 내용

- `useEpigramDelete`가 작성자의 `userId`를 받아 `["users", userId, "comments"]` 캐시를 함께 무효화하도록 수정
- `EpigramDetailPage`에서 이미 사용 중인 `me?.id`를 전달

## 🗨️ 논의 사항 (참고 사항)

- 백엔드는 에피그램 삭제 시 해당 에피그램에 달린 댓글도 cascade로 삭제한다. 따라서 마이페이지 "내 댓글" 탭(`useMyComments` → `["users", userId, "comments", { limit }]`)이 stale 상태가 되는 문제가 있었다.
- 작성자가 본인 에피그램에만 댓글을 달았다는 보장은 없지만, 가장 흔한 케이스이고 다른 사용자의 댓글 목록은 다음 방문 시 자연스럽게 refetch된다. broad invalidation(`["users"]`) 대신 본인 댓글만 타겟 무효화하여 불필요한 리페치를 피했다.
- `useCommentDelete`의 패턴(`Promise.all + invalidations 배열`)과 동일하게 맞췄다.

## 기대효과

본인이 작성한 에피그램에 본인 댓글이 있는 경우, 에피그램 삭제 후 마이페이지 "내 댓글" 탭에 stale 댓글이 남지 않는다.

Closes #329
