### PR TITLE
refactor: views 레이어 전면 simplify 리팩토링 (#333)

### DIFF
--- a/src/views/epigram-detail/ui/EpigramDetailPage.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailPage.tsx
@@ -95,9 +95,6 @@ export function EpigramDetailPage({ epigramId }: EpigramDetailPageProps): ReactE
   const { user: me, isLoading: isMeLoading } = useMe();
   const { handleDeleteClick } = useEpigramDelete(epigramId);
 
-  const isLoading = isEpigramLoading || isMeLoading;
-  const isOwner = !isLoading && epigram !== undefined && me !== null && epigram.writerId === me.id;
-
   useEffect(() => {
     if (!isCopied) return;
     const timer = setTimeout(() => setIsCopied(false), 2000);
@@ -109,9 +106,11 @@ export function EpigramDetailPage({ epigramId }: EpigramDetailPageProps): ReactE
     setIsCopied(true);
   }
 
-  if (isLoading || !epigram) {
+  if (isEpigramLoading || isMeLoading || !epigram) {
     return <SkeletonLoader />;
   }
+
+  const isOwner = me !== null && epigram.writerId === me.id;
 
   return (
     <div className="mx-auto w-full max-w-2xl px-4 py-10 tablet:max-w-3xl tablet:px-6 pc:max-w-screen-xl pc:px-16 pc:py-16 desktop:max-w-screen-2xl desktop:px-24">

--- a/src/views/epigram-edit/ui/EpigramEditPage.tsx
+++ b/src/views/epigram-edit/ui/EpigramEditPage.tsx
@@ -11,6 +11,9 @@ import { EpigramEditForm } from "@/features/epigram-edit";
 
 const UNKNOWN_AUTHOR = "알 수 없음";
 
+const PAGE_CONTAINER_CLASS =
+  "mx-auto w-full max-w-2xl px-4 py-10 tablet:max-w-3xl tablet:px-6 pc:max-w-screen-xl pc:px-16 pc:py-16 desktop:max-w-screen-2xl desktop:px-24";
+
 interface EpigramEditPageProps {
   epigramId: number;
 }
@@ -60,7 +63,7 @@ export function EpigramEditPage({ epigramId }: EpigramEditPageProps): ReactEleme
 
   if (isLoading || !epigram || isUnauthorized) {
     return (
-      <div className="mx-auto w-full max-w-2xl px-4 py-10 tablet:max-w-3xl tablet:px-6 pc:max-w-screen-xl pc:px-16 pc:py-16 desktop:max-w-screen-2xl desktop:px-24">
+      <div className={PAGE_CONTAINER_CLASS}>
         <div className="mb-8">
           <div className="h-9 w-48 animate-pulse rounded-lg bg-blue-200" />
         </div>
@@ -74,11 +77,11 @@ export function EpigramEditPage({ epigramId }: EpigramEditPageProps): ReactEleme
     author: epigram.author,
     referenceTitle: epigram.referenceTitle,
     referenceUrl: epigram.referenceUrl,
-    tagNames: epigram.tags.map((t) => t.name),
+    tagNames: epigram.tags.map((tag) => tag.name),
   });
 
   return (
-    <div className="mx-auto w-full max-w-2xl px-4 py-10 tablet:max-w-3xl tablet:px-6 pc:max-w-screen-xl pc:px-16 pc:py-16 desktop:max-w-screen-2xl desktop:px-24">
+    <div className={PAGE_CONTAINER_CLASS}>
       <div className="mb-8 pc:mb-12">
         <h1 className="text-2xl font-bold text-black-950 tablet:text-3xl pc:text-4xl desktop:text-5xl">
           에피그램 수정

--- a/src/views/epigrams/ui/EpigramsPage.tsx
+++ b/src/views/epigrams/ui/EpigramsPage.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import type { ReactElement } from "react";
+import Link from "next/link";
 
 import { ArrowUp, Plus } from "lucide-react";
-import Link from "next/link";
 
 import { EmotionSelector } from "@/features/emotion-select";
 import { useScrollToTop } from "@/shared/hooks/useScrollToTop";
 import { RecentComments } from "@/widgets/comment-section";
 import { EpigramFeed } from "@/widgets/epigram-feed";
+
+import type { ReactElement } from "react";
 
 function ScrollToTopButton(): ReactElement | null {
   const { isVisible, scrollToTop } = useScrollToTop();

--- a/src/views/feeds/ui/FeedsPage.tsx
+++ b/src/views/feeds/ui/FeedsPage.tsx
@@ -13,44 +13,92 @@ import { SectionErrorFallback } from "@/shared/ui/SectionErrorFallback";
 
 const FEEDS_PAGE_SIZE = 10;
 
+function FeedsSkeleton(): ReactElement {
+  return (
+    <div className="grid grid-cols-1 gap-4 tablet:grid-cols-2">
+      {Array.from({ length: FEEDS_PAGE_SIZE }).map((_, index) => (
+        <div key={index} className="h-40 animate-pulse rounded-2xl bg-blue-100" />
+      ))}
+    </div>
+  );
+}
+
+function FeedsEmptyState(): ReactElement {
+  return (
+    <div className="rounded-2xl border border-dashed border-line-200 bg-white">
+      <EmptyState
+        icon={
+          <BookOpenText className="h-7 w-7 text-blue-400" strokeWidth={1.5} aria-hidden="true" />
+        }
+        title="등록된 에피그램이 없습니다"
+        description="첫 번째 에피그램을 작성해 보세요."
+        action={
+          <Link
+            href="/addepigram"
+            className="inline-flex h-9 items-center justify-center rounded-xl border border-black-400 px-5 text-xs font-semibold text-black-500 transition-all duration-200 hover:bg-black-500 hover:text-white active:scale-95"
+          >
+            에피그램 만들기
+          </Link>
+        }
+      />
+    </div>
+  );
+}
+
+interface LoadMoreButtonProps {
+  isLoading: boolean;
+  onClick: () => void;
+}
+
+function LoadMoreButton({ isLoading, onClick }: LoadMoreButtonProps): ReactElement {
+  return (
+    <div className="flex justify-center pt-2">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={isLoading}
+        className="group flex items-center gap-2 rounded-full border border-line-200 bg-white px-6 py-2.5 text-sm font-medium text-black-400 shadow-sm transition-all duration-200 hover:border-blue-400 hover:text-blue-700 hover:shadow-md active:scale-95 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isLoading ? (
+          <>
+            <span
+              className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+              aria-hidden="true"
+            />
+            불러오는 중...
+          </>
+        ) : (
+          <>
+            <ChevronDown
+              className="h-4 w-4 transition-transform duration-200 group-hover:translate-y-0.5"
+              aria-hidden="true"
+            />
+            + 에피그램 더보기
+          </>
+        )}
+      </button>
+    </div>
+  );
+}
+
 function FeedsGrid(): ReactElement {
   const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useEpigrams({
     limit: FEEDS_PAGE_SIZE,
   });
 
+  if (isLoading) {
+    return <FeedsSkeleton />;
+  }
+
   const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
 
-  if (isLoading) {
-    return (
-      <div className="grid grid-cols-1 gap-4 tablet:grid-cols-2">
-        {Array.from({ length: FEEDS_PAGE_SIZE }).map((_, i) => (
-          <div key={i} className="h-40 animate-pulse rounded-2xl bg-blue-100" />
-        ))}
-      </div>
-    );
+  if (epigrams.length === 0) {
+    return <FeedsEmptyState />;
   }
 
-  if (epigrams.length === 0) {
-    return (
-      <div className="rounded-2xl border border-dashed border-line-200 bg-white">
-        <EmptyState
-          icon={
-            <BookOpenText className="h-7 w-7 text-blue-400" strokeWidth={1.5} aria-hidden="true" />
-          }
-          title="등록된 에피그램이 없습니다"
-          description="첫 번째 에피그램을 작성해 보세요."
-          action={
-            <Link
-              href="/addepigram"
-              className="inline-flex h-9 items-center justify-center rounded-xl border border-black-400 px-5 text-xs font-semibold text-black-500 transition-all duration-200 hover:bg-black-500 hover:text-white active:scale-95"
-            >
-              에피그램 만들기
-            </Link>
-          }
-        />
-      </div>
-    );
-  }
+  const handleLoadMore = (): void => {
+    fetchNextPage();
+  };
 
   return (
     <div className="flex flex-col gap-6">
@@ -61,29 +109,7 @@ function FeedsGrid(): ReactElement {
           </li>
         ))}
       </ul>
-      {hasNextPage && (
-        <div className="flex justify-center pt-2">
-          <button
-            type="button"
-            onClick={() => fetchNextPage()}
-            disabled={isFetchingNextPage}
-            className="group flex items-center gap-2 rounded-full border border-line-200 bg-white px-6 py-2.5 text-sm font-medium text-black-400 shadow-sm transition-all duration-200 hover:border-blue-400 hover:text-blue-700 hover:shadow-md active:scale-95 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isFetchingNextPage ? (
-              <span
-                className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
-                aria-hidden="true"
-              />
-            ) : (
-              <ChevronDown
-                className="h-4 w-4 transition-transform duration-200 group-hover:translate-y-0.5"
-                aria-hidden="true"
-              />
-            )}
-            {isFetchingNextPage ? "불러오는 중..." : "+ 에피그램 더보기"}
-          </button>
-        </div>
-      )}
+      {hasNextPage && <LoadMoreButton isLoading={isFetchingNextPage} onClick={handleLoadMore} />}
     </div>
   );
 }
@@ -101,7 +127,6 @@ export function FeedsPage(): ReactElement {
         </ErrorBoundary>
       </div>
 
-      {/* fixed FAB — 에피그램 만들기 */}
       <Link
         href="/addepigram"
         aria-label="에피그램 만들기"
@@ -111,7 +136,6 @@ export function FeedsPage(): ReactElement {
         에피그램 만들기
       </Link>
 
-      {/* 스크롤 위 버튼 — FAB 바로 위 */}
       {isVisible && (
         <button
           type="button"

--- a/src/views/landing/ui/AppQrPopover.tsx
+++ b/src/views/landing/ui/AppQrPopover.tsx
@@ -17,7 +17,10 @@ export function AppQrPopover(): ReactElement {
     if (!isOpen) return;
 
     function handleClickOutside(event: MouseEvent): void {
-      if (!containerRef.current?.contains(event.target as Node)) {
+      // event.target은 EventTarget | null 타입이지만 DOM 이벤트에서는 실제로 Node를 반환한다.
+      // Node.contains 시그니처 호환을 위해 단언이 불가피하다.
+      const target = event.target as Node | null;
+      if (!containerRef.current?.contains(target)) {
         setIsOpen(false);
       }
     }

--- a/src/views/landing/ui/LandingPage.tsx
+++ b/src/views/landing/ui/LandingPage.tsx
@@ -71,6 +71,16 @@ function HeroSection(): ReactElement {
   );
 }
 
+const EMOTION_TAGS = ["#우울해요", "#슬플때에필로그", "#위로가", "#마음이착잡할때"] as const;
+
+const EMOTION_BADGES = [
+  { icon: "/icon/012-heart face.png", label: "감동" },
+  { icon: "/icon/035-smiling face.png", label: "기쁨" },
+  { icon: "/icon/044-thinking.png", label: "고민" },
+  { icon: "/icon/034-sad.png", label: "슬픔" },
+  { icon: "/icon/Frame 65.png", label: "분노" },
+] as const;
+
 function EmotionSection(): ReactElement {
   return (
     <section className="flex flex-col items-center gap-10 bg-blue-200 px-6 py-20 tablet:px-[72px] desktop:px-[120px]">
@@ -108,6 +118,28 @@ function EmotionSection(): ReactElement {
     </section>
   );
 }
+
+const SAMPLE_EPIGRAMS = [
+  {
+    id: 1,
+    content: "오랫동안 꿈을 그리는 사람은 마침내 그 꿈을 닮아 간다.",
+    author: "앙드레 말로",
+    tags: ["나아가야할때", "꿈을이루고싶을때"],
+  },
+  {
+    id: 2,
+    content:
+      "이 세상에는 위대한 진실이 하나 있어. 무언가를 온 마음을 다해 원하면, 반드시 그렇게 된다.",
+    author: "파울로 코엘료",
+    tags: ["나아가야할때", "꿈을이루고싶을때"],
+  },
+  {
+    id: 3,
+    content: "당신이 꿈꿀 수 있다면, 이룰 수도 있다.",
+    author: "월트 디즈니",
+    tags: ["영감", "꿈"],
+  },
+] as const;
 
 function EpigramsSection(): ReactElement {
   return (
@@ -228,35 +260,3 @@ function CtaAppQrCard(): ReactElement {
     </div>
   );
 }
-
-const EMOTION_TAGS = ["#우울해요", "#슬플때에필로그", "#위로가", "#마음이착잡할때"] as const;
-
-const EMOTION_BADGES = [
-  { icon: "/icon/012-heart face.png", label: "감동" },
-  { icon: "/icon/035-smiling face.png", label: "기쁨" },
-  { icon: "/icon/044-thinking.png", label: "고민" },
-  { icon: "/icon/034-sad.png", label: "슬픔" },
-  { icon: "/icon/Frame 65.png", label: "분노" },
-] as const;
-
-const SAMPLE_EPIGRAMS = [
-  {
-    id: 1,
-    content: "오랫동안 꿈을 그리는 사람은 마침내 그 꿈을 닮아 간다.",
-    author: "앙드레 말로",
-    tags: ["나아가야할때", "꿈을이루고싶을때"],
-  },
-  {
-    id: 2,
-    content:
-      "이 세상에는 위대한 진실이 하나 있어. 무언가를 온 마음을 다해 원하면, 반드시 그렇게 된다.",
-    author: "파울로 코엘료",
-    tags: ["나아가야할때", "꿈을이루고싶을때"],
-  },
-  {
-    id: 3,
-    content: "당신이 꿈꿀 수 있다면, 이룰 수도 있다.",
-    author: "월트 디즈니",
-    tags: ["영감", "꿈"],
-  },
-] as const;

--- a/src/views/login/ui/LoginPage.tsx
+++ b/src/views/login/ui/LoginPage.tsx
@@ -11,8 +11,6 @@ import { LoginForm } from "@/features/auth/ui/LoginForm";
 import { EpigramLogo } from "@/shared/ui/EpigramLogo";
 
 export function LoginPage(): ReactElement {
-  const kakaoOauthUrl = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID ?? "";
-
   return (
     <div className="flex flex-1 flex-col tablet:flex-row">
       <AuthLeftPanel />
@@ -28,14 +26,9 @@ export function LoginPage(): ReactElement {
                 <LoginForm />
                 <GuestLoginButton />
               </Suspense>
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-blue-400">회원이 아니신가요?</span>
-                <Link href="/signup" className="text-sm font-medium text-black-600 hover:underline">
-                  가입하기
-                </Link>
-              </div>
+              <SignupPrompt />
             </div>
-            <SocialLoginSection kakaoOauthUrl={kakaoOauthUrl} />
+            <SocialLoginSection />
           </div>
         </div>
       </div>
@@ -43,11 +36,20 @@ export function LoginPage(): ReactElement {
   );
 }
 
-interface SocialLoginSectionProps {
-  kakaoOauthUrl: string;
+function SignupPrompt(): ReactElement {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm text-blue-400">회원이 아니신가요?</span>
+      <Link href="/signup" className="text-sm font-medium text-black-600 hover:underline">
+        가입하기
+      </Link>
+    </div>
+  );
 }
 
-function SocialLoginSection({ kakaoOauthUrl }: SocialLoginSectionProps): ReactElement {
+function SocialLoginSection(): ReactElement {
+  const kakaoOauthUrl = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID ?? "";
+
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-center gap-[14px]">

--- a/src/views/mypage/ui/MypagePage.tsx
+++ b/src/views/mypage/ui/MypagePage.tsx
@@ -13,7 +13,13 @@ import { useMe } from "@/entities/user";
 import { ProfileImageUpload, useLogout } from "@/features/auth";
 import { MypageActivity } from "@/widgets/mypage-activity";
 
-const EMOTION_OPTIONS: { value: Emotion; icon: string; label: string }[] = [
+interface EmotionOption {
+  value: Emotion;
+  icon: string;
+  label: string;
+}
+
+const EMOTION_OPTIONS: EmotionOption[] = [
   { value: "MOVED", icon: "/icon/012-heart face.png", label: "감동" },
   { value: "HAPPY", icon: "/icon/035-smiling face.png", label: "기쁨" },
   { value: "WORRIED", icon: "/icon/044-thinking.png", label: "고민" },
@@ -21,11 +27,15 @@ const EMOTION_OPTIONS: { value: Emotion; icon: string; label: string }[] = [
   { value: "ANGRY", icon: "/icon/Frame 65.png", label: "분노" },
 ];
 
-// Computed once at module load — date does not change during a session
-const _today = new Date();
-const TODAY_LABEL = `${_today.getFullYear()}.${String(_today.getMonth() + 1).padStart(2, "0")}.${String(_today.getDate()).padStart(2, "0")}`;
+function formatTodayLabel(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}.${month}.${day}`;
+}
 
-// ─── Skeletons ────────────────────────────────────────────────────────────────
+// 모듈 로드 시점에 한 번만 계산 — 세션 중 날짜는 바뀌지 않는다
+const TODAY_LABEL = formatTodayLabel(new Date());
 
 function ProfileSkeleton(): ReactElement {
   return (
@@ -36,8 +46,6 @@ function ProfileSkeleton(): ReactElement {
     </div>
   );
 }
-
-// ─── Emotion Selector ─────────────────────────────────────────────────────────
 
 interface EmotionSelectorProps {
   selectedEmotion: Emotion | null;
@@ -102,8 +110,6 @@ function EmotionSelector({
     </div>
   );
 }
-
-// ─── MypagePage ───────────────────────────────────────────────────────────────
 
 export function MypagePage(): ReactElement {
   const queryClient = useQueryClient();

--- a/src/views/search/ui/SearchPage.tsx
+++ b/src/views/search/ui/SearchPage.tsx
@@ -12,8 +12,8 @@ import { ErrorBoundary } from "@/shared/ui/ErrorBoundary";
 import { SectionErrorFallback } from "@/shared/ui/SectionErrorFallback";
 
 const SEARCH_LIMIT = 10;
-
-// ─── Skeleton ────────────────────────────────────────────────────────────────
+const ANIMATION_DELAY_MAX_INDEX = 5;
+const ANIMATION_DELAY_STEP_MS = 40;
 
 function SearchResultSkeletonItem(): ReactElement {
   return (
@@ -31,14 +31,12 @@ function SearchResultSkeletonItem(): ReactElement {
 function SearchResultSkeleton(): ReactElement {
   return (
     <div>
-      {Array.from({ length: 4 }).map((_, i) => (
-        <SearchResultSkeletonItem key={i} />
+      {Array.from({ length: 4 }).map((_, index) => (
+        <SearchResultSkeletonItem key={index} />
       ))}
     </div>
   );
 }
-
-// ─── Empty / Initial states ───────────────────────────────────────────────────
 
 interface SearchNoResultsProps {
   keyword: string;
@@ -84,8 +82,6 @@ function InitialState(): ReactElement {
   );
 }
 
-// ─── Scroll-to-top ────────────────────────────────────────────────────────────
-
 interface ScrollToTopButtonProps {
   isVisible: boolean;
   onScrollToTop: () => void;
@@ -108,8 +104,6 @@ function ScrollToTopButton({
     </button>
   );
 }
-
-// ─── Search results list (infinite scroll) ────────────────────────────────────
 
 interface SearchResultsProps {
   keyword: string;
@@ -152,7 +146,9 @@ function SearchResults({ keyword }: SearchResultsProps): ReactElement {
           <li
             key={epigram.id}
             className="animate-fade-in-up"
-            style={{ animationDelay: `${Math.min(index, 5) * 40}ms` }}
+            style={{
+              animationDelay: `${Math.min(index, ANIMATION_DELAY_MAX_INDEX) * ANIMATION_DELAY_STEP_MS}ms`,
+            }}
           >
             <SearchResultItem epigram={epigram} keyword={keyword} />
           </li>
@@ -175,8 +171,6 @@ function SearchResults({ keyword }: SearchResultsProps): ReactElement {
     </div>
   );
 }
-
-// ─── Page ─────────────────────────────────────────────────────────────────────
 
 export function SearchPage(): ReactElement {
   const {

--- a/src/views/signup/ui/SignUpPage.tsx
+++ b/src/views/signup/ui/SignUpPage.tsx
@@ -2,8 +2,7 @@ import type { ReactElement } from "react";
 
 import Link from "next/link";
 
-import { AuthLeftPanel } from "@/features/auth/ui/AuthLeftPanel";
-import { SignUpForm } from "@/features/auth/ui/SignUpForm";
+import { AuthLeftPanel, SignUpForm } from "@/features/auth";
 import { EpigramLogo } from "@/shared/ui/EpigramLogo";
 
 export function SignUpPage(): ReactElement {


### PR DESCRIPTION
## ✏️ 작업 내용

프로젝트 전체 simplify 리팩토링 스윕의 **Phase 1** — views 레이어 11개 슬라이스를 각각 격리된 worktree에서 병렬 처리 후 단일 브랜치로 통합. 순수 리팩토링이며 기능/UI/스타일 변경 없음.

**변경된 슬라이스 (9개 커밋)**

| 슬라이스 | 핵심 변경 |
|---|---|
| `epigrams` | import 순서 재정렬 (React/Next.js → 외부 → 내부 → 타입) |
| `epigram-edit` | 중복 컨테이너 className 상수 추출, 의미 없는 인자명 리네이밍 |
| `epigram-detail` | 중복 로딩 가드 제거, 불필요 지역 변수 인라인화, 타입 내로잉 활용 |
| `feeds` | `FeedsSkeleton`·`FeedsEmptyState`·`LoadMoreButton` 헬퍼 추출, 중복 삼항 통합, 무의미한 주석 제거 |
| `landing` | 상수를 소비 컴포넌트 근처로 이동, `as` 단언 범위 축소 + "왜" 주석 |
| `login` | `SignupPrompt` 헬퍼 추출, `SocialLoginSection` prop drilling 제거 (env 직접 참조) |
| `mypage` | `EmotionOption` interface 추출, `formatTodayLabel` 헬퍼 분리, 장식 주석 제거 |
| `search` | 매직 넘버 상수화(`ANIMATION_DELAY_*`), 장식 주석 제거, 인덱스 네이밍 정리 |
| `signup` | FSD 퍼블릭 API 준수 — features 내부 경로 import → 배럴 경유 |

**변경 없는 슬라이스**

- `add-epigram` — 이미 모든 원칙 준수, simplify 체크리스트 통과
- `oauth-signup` — 빈 슬라이스(0바이트 `index.ts`), 구현 없음

**검증**

- `npm run format` 통과
- `npm run lint` — 0 errors (기존 warning만 잔존)
- `npm run build` — 전체 라우트 정상 생성

## 🗨️ 논의 사항 (참고 사항)

각 슬라이스 에이전트가 스코프 밖에서 발견해 Phase 2~5로 이월한 관찰 이슈 모음.

**Phase 2 (widgets)**
- `feeds`의 `LoadMoreButton` 패턴이 `widgets/epigram-feed`, `widgets/mypage-activity`에도 중복 → 공통화 검토

**Phase 3 (features)**
- `features/auth/index.ts`에 `KakaoLoginButton` export 누락 → 현재 login view가 내부 경로로 import 중
- `features/auth/ui/KakaoLoginButton`의 prop `kakaoOauthUrl`에 실제로는 Client ID가 주입됨 → 네이밍 불일치
- `features/auth`의 `useLogout` 반환 시그니처(Promise/void) 정리 검토

**Phase 4 (entities)**
- `entities/epigram`: 상세 응답 schema에서 `author`가 문자열로 평탄화되어 `"알 수 없음"` 문자열 비교 유발 → enum/플래그로 정규화 검토
- `entities/emotion-log`: `useTodayEmotion(me?.id ?? 0)` fallback 패턴을 `enabled` 옵션으로 대체 검토

**Phase 5 (shared)**
- `ScrollToTopButton` 컴포넌트가 `views/search`·`views/feeds`·`views/epigrams` 3개 뷰에서 중복 정의 → `shared/ui`로 추출
- 스켈레톤 `animate-pulse rounded-2xl` 패턴이 여러 view에서 반복 → `SkeletonGrid` 추출 검토
- `md:` breakpoint vs 프로젝트 표준 `tablet:`·`desktop:`·`pc:` 불일치 (`landing` 내 1건)

**후속 정리**
- `src/views/oauth-signup/` 빈 디렉토리 — `src/app/oauth/callback/kakao/page.tsx`가 역할을 흡수한 것으로 보임. 삭제 또는 구현 착수 결정 필요 (별도 이슈 권장)

## 기대효과

- views 레이어 전반의 **명확성·가독성 향상** — guard clause, 의미 있는 네이밍, 불필요한 추상화 제거를 통해 각 페이지 컴포넌트가 고수준 흐름만 드러남
- **타입 안전성 강화** — 인라인 객체 타입 → 명시 interface, `as` 단언 범위 축소 및 근거 주석화
- **FSD 경계 준수** — features 내부 경로 import를 배럴 경유로 교체해 퍼블릭 API 규칙 복원
- **후속 Phase 인풋 자산화** — 뷰 리팩토링 과정에서 발견된 widgets/features/entities/shared 이슈를 논의 사항에 정리해 다음 레이어 작업의 출발점 마련

Closes #333