### PR TITLE
refactor: widgets 레이어 전면 simplify 리팩토링 (#335)

### DIFF
--- a/src/widgets/comment-section/ui/CommentSection.tsx
+++ b/src/widgets/comment-section/ui/CommentSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useState } from "react";
+import { useState } from "react";
 import type { ReactElement } from "react";
 
 import { MessageCircle, MoreVertical, Pencil, Trash2 } from "lucide-react";
@@ -19,6 +19,7 @@ import type { Comment } from "@/entities/comment";
 
 const COMMENTS_PAGE_SIZE = 5;
 const SKELETON_COUNT = 3;
+const MENU_BLUR_CLOSE_DELAY_MS = 150;
 
 interface CommentSectionProps {
   epigramId: number;
@@ -30,7 +31,7 @@ interface CommentItemProps {
   currentUserId: number | undefined;
 }
 
-function CommentItemBase({ comment, epigramId, currentUserId }: CommentItemProps): ReactElement {
+function CommentItem({ comment, epigramId, currentUserId }: CommentItemProps): ReactElement {
   const [isEditing, setIsEditing] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { open } = useModal();
@@ -42,6 +43,29 @@ function CommentItemBase({ comment, epigramId, currentUserId }: CommentItemProps
     open((onClose) => <UserProfileModal writer={comment.writer} onClose={onClose} />);
   }
 
+  function handleEditCancel(): void {
+    setIsEditing(false);
+  }
+
+  function handleMenuToggle(): void {
+    setIsMenuOpen((prev) => !prev);
+  }
+
+  function handleMenuBlur(): void {
+    // blur 직후 메뉴 내부 클릭이 소실되지 않도록 짧게 지연시킨다.
+    setTimeout(() => setIsMenuOpen(false), MENU_BLUR_CLOSE_DELAY_MS);
+  }
+
+  function handleEditStart(): void {
+    setIsMenuOpen(false);
+    setIsEditing(true);
+  }
+
+  function handleDelete(): void {
+    setIsMenuOpen(false);
+    handleDeleteClick();
+  }
+
   if (isEditing) {
     return (
       <li>
@@ -50,7 +74,7 @@ function CommentItemBase({ comment, epigramId, currentUserId }: CommentItemProps
           epigramId={epigramId}
           initialContent={comment.content}
           initialIsPrivate={comment.isPrivate}
-          onCancel={() => setIsEditing(false)}
+          onCancel={handleEditCancel}
         />
       </li>
     );
@@ -82,8 +106,8 @@ function CommentItemBase({ comment, epigramId, currentUserId }: CommentItemProps
             <div className="relative flex-shrink-0">
               <button
                 type="button"
-                onClick={() => setIsMenuOpen((prev) => !prev)}
-                onBlur={() => setTimeout(() => setIsMenuOpen(false), 150)}
+                onClick={handleMenuToggle}
+                onBlur={handleMenuBlur}
                 className="rounded-full p-1 text-black-300 transition-colors hover:bg-blue-100 hover:text-black-700"
                 aria-label="댓글 옵션"
               >
@@ -94,10 +118,7 @@ function CommentItemBase({ comment, epigramId, currentUserId }: CommentItemProps
                 <div className="absolute right-0 top-7 z-10 flex flex-col rounded-xl border border-line-200 bg-white py-1 shadow-lg">
                   <button
                     type="button"
-                    onClick={() => {
-                      setIsMenuOpen(false);
-                      setIsEditing(true);
-                    }}
+                    onClick={handleEditStart}
                     className="flex items-center gap-2 px-4 py-2 text-sm text-black-500 transition-colors hover:bg-blue-50 hover:text-black-900"
                   >
                     <Pencil size={12} />
@@ -105,10 +126,7 @@ function CommentItemBase({ comment, epigramId, currentUserId }: CommentItemProps
                   </button>
                   <button
                     type="button"
-                    onClick={() => {
-                      setIsMenuOpen(false);
-                      handleDeleteClick();
-                    }}
+                    onClick={handleDelete}
                     className="flex items-center gap-2 px-4 py-2 text-sm text-error transition-colors hover:bg-red-50"
                   >
                     <Trash2 size={12} />
@@ -125,8 +143,6 @@ function CommentItemBase({ comment, epigramId, currentUserId }: CommentItemProps
     </li>
   );
 }
-
-const CommentItem = memo(CommentItemBase);
 
 function CommentSkeleton(): ReactElement {
   return (
@@ -147,15 +163,15 @@ export function CommentSection({ epigramId }: CommentSectionProps): ReactElement
     limit: COMMENTS_PAGE_SIZE,
   });
 
-  const sentinelRef = useIntersectionObserver(
-    () => {
-      if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-    },
-    { rootMargin: "200px" }
-  );
+  function handleSentinelIntersect(): void {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  }
+
+  const sentinelRef = useIntersectionObserver(handleSentinelIntersect, { rootMargin: "200px" });
 
   const comments = data?.pages.flatMap((page) => page.list) ?? [];
   const totalCount = data?.pages[0]?.totalCount;
+  const hasComments = comments.length > 0;
 
   return (
     <section aria-label="댓글">
@@ -170,12 +186,12 @@ export function CommentSection({ epigramId }: CommentSectionProps): ReactElement
       {isLoading && (
         <ul className="flex flex-col gap-3">
           {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
-            <CommentSkeleton key={i} />
+            <CommentSkeleton key={`comment-skeleton-${i}`} />
           ))}
         </ul>
       )}
 
-      {!isLoading && comments.length === 0 && (
+      {!isLoading && !hasComments && (
         <div className="rounded-2xl border border-dashed border-line-200">
           <EmptyState
             icon={
@@ -191,7 +207,7 @@ export function CommentSection({ epigramId }: CommentSectionProps): ReactElement
         </div>
       )}
 
-      {!isLoading && comments.length > 0 && (
+      {!isLoading && hasComments && (
         <ul className="flex flex-col gap-3">
           {comments.map((comment) => (
             <CommentItem

--- a/src/widgets/comment-section/ui/RecentComments.tsx
+++ b/src/widgets/comment-section/ui/RecentComments.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, type ReactElement } from "react";
+import type { ReactElement } from "react";
 
 import { ChevronDown } from "lucide-react";
 
@@ -12,13 +12,12 @@ import { formatRelativeTime } from "@/shared/lib/date";
 import type { Comment } from "@/entities/comment";
 
 const COMMENTS_PAGE_SIZE = 4;
-const SKELETON_ITEMS = Array.from({ length: COMMENTS_PAGE_SIZE });
 
 interface CommentItemProps {
   comment: Comment;
 }
 
-function CommentItemBase({ comment }: CommentItemProps): ReactElement {
+function CommentItem({ comment }: CommentItemProps): ReactElement {
   const { open } = useModal();
 
   function handleProfileClick(): void {
@@ -51,8 +50,6 @@ function CommentItemBase({ comment }: CommentItemProps): ReactElement {
   );
 }
 
-const CommentItem = memo(CommentItemBase);
-
 interface LoadMoreButtonProps {
   isFetchingNextPage: boolean;
   onClick: () => void;
@@ -79,44 +76,54 @@ function LoadMoreButton({ isFetchingNextPage, onClick }: LoadMoreButtonProps): R
   );
 }
 
+function RecentCommentSkeleton(): ReactElement {
+  return (
+    <li className="border-t border-line-200 px-6 py-8 first:border-t-0">
+      <div className="flex items-start gap-4">
+        <div className="h-12 w-12 animate-pulse rounded-full bg-blue-200" />
+        <div className="min-w-0 flex flex-1 flex-col gap-3">
+          <div className="h-3 w-24 animate-pulse rounded bg-blue-200" />
+          <div className="h-4 w-full animate-pulse rounded bg-blue-100" />
+        </div>
+      </div>
+    </li>
+  );
+}
+
 export function RecentComments(): ReactElement {
   const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useRecentComments({
     limit: COMMENTS_PAGE_SIZE,
   });
 
-  const sentinelRef = useIntersectionObserver(
-    () => {
-      if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-    },
-    { rootMargin: "200px" }
-  );
+  function handleSentinelIntersect(): void {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  }
+
+  function handleLoadMoreClick(): void {
+    fetchNextPage();
+  }
+
+  const sentinelRef = useIntersectionObserver(handleSentinelIntersect, { rootMargin: "200px" });
 
   const comments = data?.pages.flatMap((page) => page.list) ?? [];
+  const hasComments = comments.length > 0;
 
   return (
     <section aria-label="최신 댓글">
       <h2 className="mb-4 text-xl font-bold text-black-900">최신 댓글</h2>
       {isLoading && (
         <ul className="flex flex-col">
-          {SKELETON_ITEMS.map((_, i) => (
-            <li key={i} className="border-t border-line-200 px-6 py-8 first:border-t-0">
-              <div className="flex items-start gap-4">
-                <div className="h-12 w-12 animate-pulse rounded-full bg-blue-200" />
-                <div className="min-w-0 flex flex-1 flex-col gap-3">
-                  <div className="h-3 w-24 animate-pulse rounded bg-blue-200" />
-                  <div className="h-4 w-full animate-pulse rounded bg-blue-100" />
-                </div>
-              </div>
-            </li>
+          {Array.from({ length: COMMENTS_PAGE_SIZE }).map((_, i) => (
+            <RecentCommentSkeleton key={`recent-comment-skeleton-${i}`} />
           ))}
         </ul>
       )}
-      {!isLoading && comments.length === 0 && (
+      {!isLoading && !hasComments && (
         <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-line-200 py-12 text-black-300">
           <p className="text-sm">등록된 댓글이 없습니다.</p>
         </div>
       )}
-      {!isLoading && comments.length > 0 && (
+      {!isLoading && hasComments && (
         <>
           <ul className="flex flex-col">
             {comments.map((comment) => (
@@ -124,7 +131,7 @@ export function RecentComments(): ReactElement {
             ))}
           </ul>
           {hasNextPage && (
-            <LoadMoreButton isFetchingNextPage={isFetchingNextPage} onClick={fetchNextPage} />
+            <LoadMoreButton isFetchingNextPage={isFetchingNextPage} onClick={handleLoadMoreClick} />
           )}
         </>
       )}

--- a/src/widgets/epigram-feed/ui/EpigramFeed.tsx
+++ b/src/widgets/epigram-feed/ui/EpigramFeed.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 import { BookOpenText, ChevronDown } from "lucide-react";
 import Link from "next/link";
@@ -11,6 +11,21 @@ import { ErrorBoundary } from "@/shared/ui/ErrorBoundary";
 import { SectionErrorFallback } from "@/shared/ui/SectionErrorFallback";
 
 const FEED_PAGE_SIZE = 5;
+const FEED_SKELETON_COUNT = 3;
+
+interface FeedSectionProps {
+  title: string;
+  children: ReactNode;
+}
+
+function FeedSection({ title, children }: FeedSectionProps): ReactElement {
+  return (
+    <section aria-label={title}>
+      <h2 className="mb-4 text-xl font-bold text-black-900">{title}</h2>
+      {children}
+    </section>
+  );
+}
 
 function TodayEpigramEmpty(): ReactElement {
   return (
@@ -41,32 +56,83 @@ function TodayEpigramEmpty(): ReactElement {
   );
 }
 
-function TodayEpigramSection(): ReactElement {
+function TodayEpigramBody(): ReactElement {
   const { data: todayEpigram, isLoading } = useTodayEpigram();
 
   if (isLoading) {
-    return (
-      <section aria-label="오늘의 에피그램">
-        <h2 className="mb-4 text-xl font-bold text-black-900">오늘의 에피그램</h2>
-        <div className="h-32 animate-pulse rounded-2xl bg-blue-200" />
-      </section>
-    );
+    return <div className="h-32 animate-pulse rounded-2xl bg-blue-200" />;
   }
 
   if (!todayEpigram) {
-    return (
-      <section aria-label="오늘의 에피그램">
-        <h2 className="mb-4 text-xl font-bold text-black-900">오늘의 에피그램</h2>
-        <TodayEpigramEmpty />
-      </section>
-    );
+    return <TodayEpigramEmpty />;
   }
 
+  return <EpigramListCard epigram={todayEpigram} />;
+}
+
+function TodayEpigramSection(): ReactElement {
   return (
-    <section aria-label="오늘의 에피그램">
-      <h2 className="mb-4 text-xl font-bold text-black-900">오늘의 에피그램</h2>
-      <EpigramListCard epigram={todayEpigram} />
-    </section>
+    <FeedSection title="오늘의 에피그램">
+      <TodayEpigramBody />
+    </FeedSection>
+  );
+}
+
+function FeedListSkeleton(): ReactElement {
+  return (
+    <div className="flex flex-col gap-6">
+      {Array.from({ length: FEED_SKELETON_COUNT }).map((_, index) => (
+        <div key={index} className="h-28 animate-pulse rounded-2xl bg-blue-200" />
+      ))}
+    </div>
+  );
+}
+
+function EmptyFeedState(): ReactElement {
+  return (
+    <div className="rounded-2xl border border-dashed border-line-200">
+      <EmptyState
+        icon={
+          <BookOpenText className="h-7 w-7 text-blue-400" strokeWidth={1.5} aria-hidden="true" />
+        }
+        title="등록된 에피그램이 없습니다"
+        description="첫 번째 에피그램을 작성해 보세요."
+        action={
+          <Link
+            href="/addepigram"
+            className="inline-flex h-9 items-center justify-center rounded-xl border border-black-400 px-5 text-xs font-semibold text-black-500 transition-all duration-200 hover:bg-black-500 hover:text-white active:scale-95"
+          >
+            에피그램 만들기
+          </Link>
+        }
+      />
+    </div>
+  );
+}
+
+interface LoadMoreButtonProps {
+  isLoading: boolean;
+  onClick: () => void;
+}
+
+function LoadMoreButton({ isLoading, onClick }: LoadMoreButtonProps): ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isLoading}
+      className="group mx-auto mt-2 flex items-center gap-2 rounded-full border border-line-200 bg-white px-6 py-2.5 text-sm font-medium text-black-400 shadow-sm transition-all duration-200 hover:border-blue-400 hover:text-blue-700 hover:shadow-md active:scale-95 disabled:cursor-not-allowed disabled:opacity-60"
+    >
+      {isLoading ? (
+        <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+      ) : (
+        <ChevronDown
+          className="h-4 w-4 transition-transform duration-200 group-hover:translate-y-0.5"
+          aria-hidden="true"
+        />
+      )}
+      {isLoading ? "불러오는 중..." : "에피그램 더보기"}
+    </button>
   );
 }
 
@@ -75,63 +141,26 @@ function EpigramFeedList(): ReactElement {
     limit: FEED_PAGE_SIZE,
   });
 
+  if (isLoading) {
+    return <FeedListSkeleton />;
+  }
+
   const epigrams = data?.pages.flatMap((page) => page.list) ?? [];
 
-  if (isLoading) {
-    return (
-      <div className="flex flex-col gap-6">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="h-28 animate-pulse rounded-2xl bg-blue-200" />
-        ))}
-      </div>
-    );
+  if (epigrams.length === 0) {
+    return <EmptyFeedState />;
   }
 
-  if (epigrams.length === 0) {
-    return (
-      <div className="rounded-2xl border border-dashed border-line-200">
-        <EmptyState
-          icon={
-            <BookOpenText className="h-7 w-7 text-blue-400" strokeWidth={1.5} aria-hidden="true" />
-          }
-          title="등록된 에피그램이 없습니다"
-          description="첫 번째 에피그램을 작성해 보세요."
-          action={
-            <Link
-              href="/addepigram"
-              className="inline-flex h-9 items-center justify-center rounded-xl border border-black-400 px-5 text-xs font-semibold text-black-500 transition-all duration-200 hover:bg-black-500 hover:text-white active:scale-95"
-            >
-              에피그램 만들기
-            </Link>
-          }
-        />
-      </div>
-    );
-  }
+  const handleLoadMore = (): void => {
+    fetchNextPage();
+  };
 
   return (
     <div className="flex flex-col gap-6">
       {epigrams.map((epigram) => (
         <EpigramListCard key={epigram.id} epigram={epigram} />
       ))}
-      {hasNextPage && (
-        <button
-          type="button"
-          onClick={() => fetchNextPage()}
-          disabled={isFetchingNextPage}
-          className="group mx-auto mt-2 flex items-center gap-2 rounded-full border border-line-200 bg-white px-6 py-2.5 text-sm font-medium text-black-400 shadow-sm transition-all duration-200 hover:border-blue-400 hover:text-blue-700 hover:shadow-md active:scale-95 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {isFetchingNextPage ? (
-            <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-          ) : (
-            <ChevronDown
-              className="h-4 w-4 transition-transform duration-200 group-hover:translate-y-0.5"
-              aria-hidden="true"
-            />
-          )}
-          {isFetchingNextPage ? "불러오는 중..." : "에피그램 더보기"}
-        </button>
-      )}
+      {hasNextPage && <LoadMoreButton isLoading={isFetchingNextPage} onClick={handleLoadMore} />}
     </div>
   );
 }
@@ -142,12 +171,11 @@ export function EpigramFeed(): ReactElement {
       <ErrorBoundary fallback={(_, reset) => <SectionErrorFallback reset={reset} />}>
         <TodayEpigramSection />
       </ErrorBoundary>
-      <section aria-label="최신 에피그램">
-        <h2 className="mb-4 text-xl font-bold text-black-900">최신 에피그램</h2>
+      <FeedSection title="최신 에피그램">
         <ErrorBoundary fallback={(_, reset) => <SectionErrorFallback reset={reset} />}>
           <EpigramFeedList />
         </ErrorBoundary>
-      </section>
+      </FeedSection>
     </div>
   );
 }

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -121,47 +121,55 @@ function UserSection({ size }: UserSectionProps): ReactElement {
   );
 }
 
+interface HeaderBarProps {
+  containerClassName: string;
+  size: "sm" | "lg";
+  navTextSize: "sm" | "md";
+  innerGapClassName: string;
+}
+
+function HeaderBar({
+  containerClassName,
+  size,
+  navTextSize,
+  innerGapClassName,
+}: HeaderBarProps): ReactElement {
+  return (
+    <div className={containerClassName}>
+      <div className={cn("flex items-center", innerGapClassName)}>
+        <Logo size={size} />
+        <nav className="flex gap-6" aria-label="주요 메뉴">
+          {NAV_LINKS.map((link) => (
+            <NavLink key={link.href} href={link.href} label={link.label} textSize={navTextSize} />
+          ))}
+        </nav>
+      </div>
+      <UserSection size={size} />
+    </div>
+  );
+}
+
 export function Header(): ReactElement {
   return (
     <header className="sticky top-0 z-50 w-full border-b border-line-100 bg-white/90 backdrop-blur-md">
-      {/* Mobile (base ~ 743px): 로고 + 텍스트 링크 / 유저 */}
-      <div className="flex h-[52px] items-center justify-between px-6 tablet:hidden">
-        <div className="flex items-center gap-6">
-          <Logo size="sm" />
-          <nav className="flex gap-6" aria-label="주요 메뉴">
-            {NAV_LINKS.map((link) => (
-              <NavLink key={link.href} href={link.href} label={link.label} textSize="sm" />
-            ))}
-          </nav>
-        </div>
-        <UserSection size="sm" />
-      </div>
-
-      {/* Tablet (744px ~ 1279px): 로고 + 텍스트 링크 / 유저 */}
-      <div className="hidden h-[60px] items-center justify-between px-[72px] tablet:flex pc:hidden">
-        <div className="flex items-center gap-6">
-          <Logo size="sm" />
-          <nav className="flex gap-6" aria-label="주요 메뉴">
-            {NAV_LINKS.map((link) => (
-              <NavLink key={link.href} href={link.href} label={link.label} textSize="sm" />
-            ))}
-          </nav>
-        </div>
-        <UserSection size="sm" />
-      </div>
-
-      {/* Desktop (1280px+): 로고 + 텍스트 링크 / 유저 */}
-      <div className="hidden h-[80px] items-center justify-between px-[120px] pc:flex">
-        <div className="flex items-center gap-9">
-          <Logo size="lg" />
-          <nav className="flex gap-6" aria-label="주요 메뉴">
-            {NAV_LINKS.map((link) => (
-              <NavLink key={link.href} href={link.href} label={link.label} textSize="md" />
-            ))}
-          </nav>
-        </div>
-        <UserSection size="lg" />
-      </div>
+      <HeaderBar
+        containerClassName="flex h-[52px] items-center justify-between px-6 tablet:hidden"
+        size="sm"
+        navTextSize="sm"
+        innerGapClassName="gap-6"
+      />
+      <HeaderBar
+        containerClassName="hidden h-[60px] items-center justify-between px-[72px] tablet:flex pc:hidden"
+        size="sm"
+        navTextSize="sm"
+        innerGapClassName="gap-6"
+      />
+      <HeaderBar
+        containerClassName="hidden h-[80px] items-center justify-between px-[120px] pc:flex"
+        size="lg"
+        navTextSize="md"
+        innerGapClassName="gap-9"
+      />
     </header>
   );
 }

--- a/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionCalendar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, type ReactElement } from "react";
+import { useState, type ReactElement } from "react";
 
 import Image from "next/image";
 
@@ -8,7 +8,7 @@ import { ChevronLeft, ChevronRight, ChevronDown } from "lucide-react";
 
 import { useMonthlyEmotions } from "@/entities/emotion-log";
 
-import type { Emotion } from "@/entities/emotion-log";
+import type { Emotion, EmotionLog } from "@/entities/emotion-log";
 
 const EMOTION_ICONS: Record<Emotion, string> = {
   MOVED: "/icon/012-heart face.png",
@@ -40,44 +40,56 @@ interface CalendarCell {
   dateKey: string;
 }
 
+function formatDateKey(year: number, month: number, day: number): string {
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function getPrevMonth(year: number, month: number): { year: number; month: number } {
+  if (month === 1) return { year: year - 1, month: 12 };
+  return { year, month: month - 1 };
+}
+
+function getNextMonth(year: number, month: number): { year: number; month: number } {
+  if (month === 12) return { year: year + 1, month: 1 };
+  return { year, month: month + 1 };
+}
+
 function buildCalendarCells(year: number, month: number): CalendarCell[] {
   const firstDayOfWeek = new Date(year, month - 1, 1).getDay();
   const daysInMonth = new Date(year, month, 0).getDate();
   const daysInPrevMonth = new Date(year, month - 1, 0).getDate();
+  const prev = getPrevMonth(year, month);
+  const next = getNextMonth(year, month);
 
   const cells: CalendarCell[] = [];
 
   for (let i = firstDayOfWeek - 1; i >= 0; i--) {
     const day = daysInPrevMonth - i;
-    const prevMonth = month === 1 ? 12 : month - 1;
-    const prevYear = month === 1 ? year - 1 : year;
     cells.push({
       day,
       isCurrentMonth: false,
-      dateKey: `${prevYear}-${String(prevMonth).padStart(2, "0")}-${String(day).padStart(2, "0")}`,
+      dateKey: formatDateKey(prev.year, prev.month, day),
     });
   }
 
-  for (let d = 1; d <= daysInMonth; d++) {
+  for (let day = 1; day <= daysInMonth; day++) {
     cells.push({
-      day: d,
+      day,
       isCurrentMonth: true,
-      dateKey: `${year}-${String(month).padStart(2, "0")}-${String(d).padStart(2, "0")}`,
+      dateKey: formatDateKey(year, month, day),
     });
   }
 
   const remainder = cells.length % 7;
-  if (remainder !== 0) {
-    const nextMonth = month === 12 ? 1 : month + 1;
-    const nextYear = month === 12 ? year + 1 : year;
-    const toAdd = 7 - remainder;
-    for (let i = 1; i <= toAdd; i++) {
-      cells.push({
-        day: i,
-        isCurrentMonth: false,
-        dateKey: `${nextYear}-${String(nextMonth).padStart(2, "0")}-${String(i).padStart(2, "0")}`,
-      });
-    }
+  if (remainder === 0) return cells;
+
+  const toAdd = 7 - remainder;
+  for (let day = 1; day <= toAdd; day++) {
+    cells.push({
+      day,
+      isCurrentMonth: false,
+      dateKey: formatDateKey(next.year, next.month, day),
+    });
   }
 
   return cells;
@@ -89,20 +101,25 @@ interface MonthNavigationProps {
   size?: "sm" | "md";
 }
 
+const NAV_BUTTON_BASE =
+  "flex items-center justify-center rounded-full transition hover:bg-background active:scale-90";
+
+const NAV_SIZE_CLASSES: Record<"sm" | "md", { button: string; icon: string }> = {
+  sm: { button: "h-8 w-8", icon: "h-4 w-4 text-black-600" },
+  md: { button: "h-9 w-9", icon: "h-5 w-5 text-black-600" },
+};
+
 function MonthNavigation({ onPrev, onNext, size = "md" }: MonthNavigationProps): ReactElement {
-  const btnClass =
-    size === "sm"
-      ? "flex h-8 w-8 items-center justify-center rounded-full transition hover:bg-background active:scale-90"
-      : "flex h-9 w-9 items-center justify-center rounded-full transition hover:bg-background active:scale-90";
-  const iconClass = size === "sm" ? "h-4 w-4 text-black-600" : "h-5 w-5 text-black-600";
+  const { button, icon } = NAV_SIZE_CLASSES[size];
+  const btnClass = `${NAV_BUTTON_BASE} ${button}`;
 
   return (
     <div className="flex items-center gap-2">
       <button type="button" aria-label="이전 달" onClick={onPrev} className={btnClass}>
-        <ChevronLeft className={iconClass} strokeWidth={2.5} />
+        <ChevronLeft className={icon} strokeWidth={2.5} />
       </button>
       <button type="button" aria-label="다음 달" onClick={onNext} className={btnClass}>
-        <ChevronRight className={iconClass} strokeWidth={2.5} />
+        <ChevronRight className={icon} strokeWidth={2.5} />
       </button>
     </div>
   );
@@ -110,6 +127,15 @@ function MonthNavigation({ onPrev, onNext, size = "md" }: MonthNavigationProps):
 
 interface EmotionCalendarProps {
   userId: number;
+}
+
+function buildEmotionByDate(emotionLogs: EmotionLog[]): Map<string, Emotion> {
+  const map = new Map<string, Emotion>();
+  for (const log of emotionLogs) {
+    const dateKey = new Date(log.createdAt).toLocaleDateString("sv");
+    map.set(dateKey, log.emotion);
+  }
+  return map;
 }
 
 export function EmotionCalendar({ userId }: EmotionCalendarProps): ReactElement {
@@ -120,35 +146,19 @@ export function EmotionCalendar({ userId }: EmotionCalendarProps): ReactElement 
 
   const { data: emotionLogs = [] } = useMonthlyEmotions({ userId, year, month });
 
-  const emotionByDate = useMemo(
-    () =>
-      new Map<string, Emotion>(
-        emotionLogs.map((log) => {
-          const dateKey = new Date(log.createdAt).toLocaleDateString("sv");
-          return [dateKey, log.emotion];
-        })
-      ),
-    [emotionLogs]
-  );
-
-  const cells = useMemo(() => buildCalendarCells(year, month), [year, month]);
+  const emotionByDate = buildEmotionByDate(emotionLogs);
+  const cells = buildCalendarCells(year, month);
 
   function handlePrevMonth(): void {
-    if (month === 1) {
-      setYear((y) => y - 1);
-      setMonth(12);
-    } else {
-      setMonth((m) => m - 1);
-    }
+    const prev = getPrevMonth(year, month);
+    setYear(prev.year);
+    setMonth(prev.month);
   }
 
   function handleNextMonth(): void {
-    if (month === 12) {
-      setYear((y) => y + 1);
-      setMonth(1);
-    } else {
-      setMonth((m) => m + 1);
-    }
+    const next = getNextMonth(year, month);
+    setYear(next.year);
+    setMonth(next.month);
   }
 
   function handleFilterSelect(emotion: Emotion | null): void {
@@ -156,10 +166,14 @@ export function EmotionCalendar({ userId }: EmotionCalendarProps): ReactElement 
     setIsFilterOpen(false);
   }
 
+  function handleToggleFilter(): void {
+    setIsFilterOpen((open) => !open);
+  }
+
   function isToday(cell: CalendarCell): boolean {
-    return (
-      cell.isCurrentMonth && year === TODAY_YEAR && month === TODAY_MONTH && cell.day === TODAY_DATE
-    );
+    if (!cell.isCurrentMonth) return false;
+    if (year !== TODAY_YEAR || month !== TODAY_MONTH) return false;
+    return cell.day === TODAY_DATE;
   }
 
   function getVisibleEmotion(cell: CalendarCell): Emotion | undefined {
@@ -193,7 +207,7 @@ export function EmotionCalendar({ userId }: EmotionCalendarProps): ReactElement 
           <div className="relative">
             <button
               type="button"
-              onClick={() => setIsFilterOpen((v) => !v)}
+              onClick={handleToggleFilter}
               className="flex items-center gap-1 rounded-xl bg-background px-3 py-1.5 text-xs font-semibold text-gray-200 transition hover:bg-blue-200 tablet:text-sm"
             >
               필터: {filterLabel}

--- a/src/widgets/mypage-activity/ui/EmotionPieChart.tsx
+++ b/src/widgets/mypage-activity/ui/EmotionPieChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, type ReactElement } from "react";
+import { type ReactElement } from "react";
 
 import Image from "next/image";
 
@@ -30,23 +30,36 @@ interface ChartDatum {
   percentage: number;
 }
 
-function buildChartData(emotionLogs: EmotionLog[]): ChartDatum[] {
-  const counts = new Map<Emotion, number>();
+function findTopEmotion(chartData: ChartDatum[]): ChartDatum {
+  let top = chartData[0];
+  for (const datum of chartData) {
+    if (datum.count > top.count) {
+      top = datum;
+    }
+  }
+  return top;
+}
 
+function buildChartData(emotionLogs: EmotionLog[]): ChartDatum[] {
+  if (emotionLogs.length === 0) return [];
+
+  const counts = new Map<Emotion, number>();
   for (const log of emotionLogs) {
     counts.set(log.emotion, (counts.get(log.emotion) ?? 0) + 1);
   }
 
   const total = emotionLogs.length;
-
-  return EMOTION_ORDER.filter((emotion) => counts.has(emotion)).map((emotion) => {
-    const count = counts.get(emotion)!;
-    return {
+  const result: ChartDatum[] = [];
+  for (const emotion of EMOTION_ORDER) {
+    const count = counts.get(emotion);
+    if (count === undefined) continue;
+    result.push({
       emotion,
       count,
       percentage: Math.round((count / total) * 100),
-    };
-  });
+    });
+  }
+  return result;
 }
 
 interface EmotionPieChartProps {
@@ -54,7 +67,7 @@ interface EmotionPieChartProps {
 }
 
 export function EmotionPieChart({ emotionLogs }: EmotionPieChartProps): ReactElement {
-  const chartData = useMemo(() => buildChartData(emotionLogs), [emotionLogs]);
+  const chartData = buildChartData(emotionLogs);
 
   if (chartData.length === 0) {
     return (
@@ -74,7 +87,7 @@ export function EmotionPieChart({ emotionLogs }: EmotionPieChartProps): ReactEle
     );
   }
 
-  const topEmotion = chartData.reduce((max, d) => (d.count > max.count ? d : max));
+  const topEmotion = findTopEmotion(chartData);
 
   return (
     <section className="w-full rounded-2xl bg-white px-6 py-6 shadow-sm ring-1 ring-blue-200">

--- a/src/widgets/mypage-activity/ui/MypageActivity.tsx
+++ b/src/widgets/mypage-activity/ui/MypageActivity.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState, type ReactElement } from "react";
+import { useEffect, useState, type ReactElement } from "react";
 
 import Image from "next/image";
 import Link from "next/link";
@@ -215,9 +215,6 @@ function TabbedSection({ userId }: TabbedSectionProps): ReactElement {
   const [epigramCount, setEpigramCount] = useState(0);
   const [commentCount, setCommentCount] = useState(0);
 
-  const handleEpigramCount = useCallback((count: number) => setEpigramCount(count), []);
-  const handleCommentCount = useCallback((count: number) => setCommentCount(count), []);
-
   return (
     <div className="flex flex-col gap-8">
       {/* Tab header */}
@@ -246,10 +243,10 @@ function TabbedSection({ userId }: TabbedSectionProps): ReactElement {
 
       {/* Tab content — both lists stay mounted so counts stay accurate after tab switch */}
       <div className={activeTab !== "epigrams" ? "hidden" : ""}>
-        <MyEpigramList userId={userId} onTotalCount={handleEpigramCount} />
+        <MyEpigramList userId={userId} onTotalCount={setEpigramCount} />
       </div>
       <div className={activeTab !== "comments" ? "hidden" : ""}>
-        <MyCommentList userId={userId} onTotalCount={handleCommentCount} />
+        <MyCommentList userId={userId} onTotalCount={setCommentCount} />
       </div>
     </div>
   );


### PR DESCRIPTION
## ✏️ 작업 내용

프로젝트 전체 simplify 리팩토링 스윕의 **Phase 2** — widgets 레이어 4개 슬라이스를 격리 worktree에서 병렬 처리 후 단일 브랜치로 통합. 순수 리팩토링이며 기능/UI/스타일 변경 없음.

**변경된 슬라이스 (4개 커밋)**

| 슬라이스 | 핵심 변경 |
|---|---|
| `header` | `HeaderBar` 헬퍼로 mobile/tablet/desktop 3중 레이아웃 블록 통합, `logoSize`/`userSize` 오버랩 prop을 단일 `size`로 병합, 무의미 주석 제거 |
| `comment-section` | 인라인 화살표 핸들러 → `handle` 접두사 네임드 함수 추출, 조기 최적화 `memo` 제거, 매직넘버 `150ms` 상수화 및 "왜" 주석, 스켈레톤 구조 정리 |
| `epigram-feed` | `FeedSection` 공통 헬퍼로 section 래퍼 3중 중복 통합, 상태별 UI 헬퍼(`FeedListSkeleton`/`EmptyFeedState`/`LoadMoreButton`) 분리, `handleLoadMore` 추출, `FEED_SKELETON_COUNT` 상수화 |
| `mypage-activity` | 불필요한 `useMemo` 3개·`useCallback` 2개 제거, `buildCalendarCells` 내부 헬퍼 추출(`getPrevMonth`/`getNextMonth`/`formatDateKey`), 이중 삼항 → `NAV_SIZE_CLASSES` 룩업 테이블, non-null assertion 제거 |

**검증**

- `npm run format` 통과
- `npm run lint` — 0 errors (기존 warning만 잔존)
- `npm run build` — 전체 라우트 정상 생성

## 🗨️ 논의 사항 (참고 사항)

**Phase 3 (features) 이월 이슈**
- `features/comment-delete`의 `useCommentDelete`가 `(commentId, epigramId)` 위치 인자 2개로 시그니처 → 호출부에서 순서 모호. 객체 인자로 개선 검토

**Phase 5 (shared) 이월 이슈**
- `LoadMoreButton` 패턴이 `views/feeds`·`widgets/epigram-feed`·`widgets/mypage-activity`·`widgets/comment-section` 등 **4+곳**에서 중복 — `shared/ui`로 공통 추출 필요
- `h-28 animate-pulse rounded-2xl bg-blue-200` 카드 스켈레톤 패턴 여러 위젯에서 반복 → 공통 `Skeleton`/`SkeletonGrid` 검토
- `ErrorBoundary fallback={(_, reset) => <SectionErrorFallback reset={reset} />}` 래핑 패턴 반복 가능성 → `SectionErrorBoundary` 공통 래퍼 후보

**별도 이슈 권장**
- `widgets/mypage-activity` 내부 `MyEpigramList`/`MyCommentList`가 `useEffect`로 `totalCount`를 부모(`TabbedSection`)에 리프트업 — 쿼리를 상위로 끌어올려 서버 상태·UI 상태를 한곳에서 관리하는 구조 변경이 더 깔끔하나, 순수 단순화 범위를 넘어 별도 이슈로 추적 권장

## 기대효과

- widgets 레이어의 **가독성 향상** — 반복 레이아웃·상태 분기 UI가 헬퍼 컴포넌트로 흡수되어 메인 컴포넌트는 고수준 흐름만 읽힘
- **조기 최적화 제거** — 실측 근거 없이 붙어있던 `useMemo`/`useCallback`/`memo`를 헌법 VI에 따라 정리
- **타입 안전성 강화** — non-null assertion 제거, 매직넘버 상수화와 "왜" 주석 추가
- **공통화 여지 식별** — `LoadMoreButton`, 카드 스켈레톤, SectionErrorBoundary 등 Phase 5의 shared 리팩토링 타깃 명확화

Closes #335