### PR TITLE
refactor: entities 레이어 전면 simplify 리팩토링 (#339)

### DIFF
--- a/src/entities/comment/api/buildCursorParams.ts
+++ b/src/entities/comment/api/buildCursorParams.ts
@@ -1,0 +1,5 @@
+export function buildCursorParams(limit: number, cursor?: number): URLSearchParams {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (cursor !== undefined) params.set("cursor", String(cursor));
+  return params;
+}

--- a/src/entities/comment/api/server.ts
+++ b/src/entities/comment/api/server.ts
@@ -1,6 +1,8 @@
 // Server-only: DO NOT import in client components
 import { BACKEND_BASE } from "@/shared/config/backend";
 
+import { buildCursorParams } from "./buildCursorParams";
+
 import { commentListResponseSchema } from "../model/schema";
 import type { CommentListResponse } from "../model/schema";
 
@@ -13,8 +15,7 @@ export async function fetchRecentCommentsPageServer({
   limit,
   pageParam,
 }: FetchCommentsPageParams): Promise<CommentListResponse> {
-  const params = new URLSearchParams({ limit: String(limit) });
-  if (pageParam !== undefined) params.set("cursor", String(pageParam));
+  const params = buildCursorParams(limit, pageParam);
 
   const res = await fetch(`${BACKEND_BASE}/comments?${params}`, {
     next: { revalidate: 30, tags: ["comments"] },

--- a/src/entities/comment/api/useEpigramComments.ts
+++ b/src/entities/comment/api/useEpigramComments.ts
@@ -6,6 +6,9 @@ import {
 
 import { apiClient } from "@/shared/api/client";
 
+import { buildCursorParams } from "./buildCursorParams";
+
+import { commentQueryKeys } from "../model/queryKeys";
 import { commentListResponseSchema, type CommentListResponse } from "../model/schema";
 
 interface UseEpigramCommentsParams {
@@ -21,12 +24,10 @@ export function useEpigramComments({
   Error
 > {
   return useInfiniteQuery({
-    queryKey: ["epigrams", epigramId, "comments", { limit }],
+    queryKey: commentQueryKeys.byEpigramWithParams(epigramId, { limit }),
     enabled: epigramId > 0,
     queryFn: async ({ pageParam }) => {
-      const params = new URLSearchParams({ limit: String(limit) });
-      if (pageParam !== undefined) params.set("cursor", String(pageParam));
-
+      const params = buildCursorParams(limit, pageParam);
       const response = await apiClient.get<unknown>(
         `/api/epigrams/${epigramId}/comments?${params}`
       );

--- a/src/entities/comment/api/useMyComments.ts
+++ b/src/entities/comment/api/useMyComments.ts
@@ -6,6 +6,9 @@ import {
 
 import { apiClient } from "@/shared/api/client";
 
+import { buildCursorParams } from "./buildCursorParams";
+
+import { commentQueryKeys } from "../model/queryKeys";
 import { commentListResponseSchema, type CommentListResponse } from "../model/schema";
 
 interface UseMyCommentsParams {
@@ -21,12 +24,10 @@ export function useMyComments({
   Error
 > {
   return useInfiniteQuery({
-    queryKey: ["users", userId, "comments", { limit }],
+    queryKey: commentQueryKeys.byUserWithParams(userId, { limit }),
     enabled: userId > 0,
     queryFn: async ({ pageParam }) => {
-      const params = new URLSearchParams({ limit: String(limit) });
-      if (pageParam !== undefined) params.set("cursor", String(pageParam));
-
+      const params = buildCursorParams(limit, pageParam);
       const response = await apiClient.get<unknown>(`/api/users/${userId}/comments?${params}`);
       return commentListResponseSchema.parse(response.data);
     },

--- a/src/entities/comment/api/useRecentComments.ts
+++ b/src/entities/comment/api/useRecentComments.ts
@@ -6,6 +6,9 @@ import {
 
 import { apiClient } from "@/shared/api/client";
 
+import { buildCursorParams } from "./buildCursorParams";
+
+import { commentQueryKeys } from "../model/queryKeys";
 import { commentListResponseSchema, type CommentListResponse } from "../model/schema";
 
 interface UseRecentCommentsParams {
@@ -19,11 +22,9 @@ export function useRecentComments({
   Error
 > {
   return useInfiniteQuery({
-    queryKey: ["comments", { limit }],
+    queryKey: commentQueryKeys.recent({ limit }),
     queryFn: async ({ pageParam }) => {
-      const params = new URLSearchParams({ limit: String(limit) });
-      if (pageParam !== undefined) params.set("cursor", String(pageParam));
-
+      const params = buildCursorParams(limit, pageParam);
       const response = await apiClient.get<unknown>(`/api/comments?${params}`);
       return commentListResponseSchema.parse(response.data);
     },

--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -1,6 +1,8 @@
 export { writerSchema, commentSchema, commentListResponseSchema } from "./model/schema";
 export type { Writer, Comment, CommentListResponse } from "./model/schema";
 
+export { commentQueryKeys } from "./model/queryKeys";
+
 export { useRecentComments } from "./api/useRecentComments";
 export { useEpigramComments } from "./api/useEpigramComments";
 export { useMyComments } from "./api/useMyComments";

--- a/src/entities/comment/model/queryKeys.ts
+++ b/src/entities/comment/model/queryKeys.ts
@@ -1,0 +1,17 @@
+/**
+ * comment 엔티티 쿼리키 팩토리.
+ *
+ * features/comment-create·comment-edit·comment-delete 등 소비자들이
+ * 에피그램·유저별 댓글 캐시를 일관된 키로 무효화할 수 있도록 한 곳에 모은다.
+ * 하드코딩된 `["epigrams", id, "comments"]` 반복 대신 이 팩토리를 사용한다.
+ */
+export const commentQueryKeys = {
+  all: ["comments"] as const,
+  recent: (params: { limit: number }) => ["comments", params] as const,
+  byEpigram: (epigramId: number) => ["epigrams", epigramId, "comments"] as const,
+  byEpigramWithParams: (epigramId: number, params: { limit: number }) =>
+    ["epigrams", epigramId, "comments", params] as const,
+  byUser: (userId: number) => ["users", userId, "comments"] as const,
+  byUserWithParams: (userId: number, params: { limit: number }) =>
+    ["users", userId, "comments", params] as const,
+} as const;

--- a/src/entities/emotion-log/api/useMonthlyEmotions.ts
+++ b/src/entities/emotion-log/api/useMonthlyEmotions.ts
@@ -10,20 +10,25 @@ interface UseMonthlyEmotionsParams {
   month: number;
 }
 
-export function useMonthlyEmotions({
+async function fetchMonthlyEmotions({
   userId,
   year,
   month,
-}: UseMonthlyEmotionsParams): UseQueryResult<EmotionLog[], Error> {
+}: UseMonthlyEmotionsParams): Promise<EmotionLog[]> {
+  const response = await apiClient.get<unknown>("/api/emotionLogs/monthly", {
+    params: { userId, year, month },
+  });
+  return emotionLogArraySchema.parse(response.data);
+}
+
+export function useMonthlyEmotions(
+  params: UseMonthlyEmotionsParams
+): UseQueryResult<EmotionLog[], Error> {
+  const { userId, year, month } = params;
+  // userId는 API 스펙상 minimum: 1 — 0/falsy이면(/me 로드 전) 요청을 보내지 않는다.
   return useQuery({
     queryKey: ["emotionLogs", "monthly", userId, year, month],
-    queryFn: async () => {
-      const response = await apiClient.get<unknown>("/api/emotionLogs/monthly", {
-        params: { userId, year, month },
-      });
-      return emotionLogArraySchema.parse(response.data);
-    },
-    // userId 0 or negative is invalid per API spec (minimum: 1)
     enabled: userId > 0,
+    queryFn: () => fetchMonthlyEmotions(params),
   });
 }

--- a/src/entities/emotion-log/api/useTodayEmotion.ts
+++ b/src/entities/emotion-log/api/useTodayEmotion.ts
@@ -4,16 +4,20 @@ import { apiClient } from "@/shared/api/client";
 
 import { emotionLogSchema, type EmotionLog } from "../model/schema";
 
+async function fetchTodayEmotion(userId: number): Promise<EmotionLog | null> {
+  const response = await apiClient.get<unknown>("/api/emotionLogs/today", {
+    params: { userId },
+  });
+  // 백엔드는 오늘 기록이 없을 때 null/빈 응답을 반환하므로 스키마 파싱 전에 걸러낸다.
+  if (response.data == null || typeof response.data !== "object") return null;
+  return emotionLogSchema.parse(response.data);
+}
+
 export function useTodayEmotion(userId: number): UseQueryResult<EmotionLog | null, Error> {
+  // userId가 0/falsy이면(아직 /me 로드 전) 요청을 보내지 않는다. 호출부의 fallback(0)과 짝을 이룬다.
   return useQuery({
     queryKey: ["emotionLogs", "today", userId],
     enabled: userId > 0,
-    queryFn: async () => {
-      const response = await apiClient.get<unknown>("/api/emotionLogs/today", {
-        params: { userId },
-      });
-      if (response.data == null || typeof response.data !== "object") return null;
-      return emotionLogSchema.parse(response.data);
-    },
+    queryFn: () => fetchTodayEmotion(userId),
   });
 }

--- a/src/entities/epigram/api/buildListParams.ts
+++ b/src/entities/epigram/api/buildListParams.ts
@@ -1,0 +1,19 @@
+interface EpigramListParams {
+  limit: number;
+  pageParam?: number;
+  keyword?: string;
+  writerId?: number;
+}
+
+export function buildEpigramListParams({
+  limit,
+  pageParam,
+  keyword,
+  writerId,
+}: EpigramListParams): URLSearchParams {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (pageParam !== undefined) params.set("cursor", String(pageParam));
+  if (keyword) params.set("keyword", keyword);
+  if (writerId !== undefined) params.set("writerId", String(writerId));
+  return params;
+}

--- a/src/entities/epigram/api/server.ts
+++ b/src/entities/epigram/api/server.ts
@@ -1,7 +1,9 @@
 // Server-only: DO NOT import in client components
 import { BACKEND_BASE } from "@/shared/config/backend";
 
+import { buildEpigramListParams } from "./buildListParams";
 import { epigramListResponseSchema, epigramSchema } from "../model/schema";
+
 import type { Epigram, EpigramListResponse } from "../model/schema";
 
 interface FetchEpigramsPageParams {
@@ -11,17 +13,10 @@ interface FetchEpigramsPageParams {
   writerId?: number;
 }
 
-export async function fetchEpigramsPageServer({
-  limit,
-  pageParam,
-  keyword,
-  writerId,
-}: FetchEpigramsPageParams): Promise<EpigramListResponse> {
-  const params = new URLSearchParams({ limit: String(limit) });
-  if (pageParam !== undefined) params.set("cursor", String(pageParam));
-  if (keyword) params.set("keyword", keyword);
-  if (writerId !== undefined) params.set("writerId", String(writerId));
-
+export async function fetchEpigramsPageServer(
+  args: FetchEpigramsPageParams
+): Promise<EpigramListResponse> {
+  const params = buildEpigramListParams(args);
   const res = await fetch(`${BACKEND_BASE}/epigrams?${params}`, {
     next: { revalidate: 30, tags: ["epigrams"] },
     signal: AbortSignal.timeout(5000),

--- a/src/entities/epigram/api/updateEpigram.ts
+++ b/src/entities/epigram/api/updateEpigram.ts
@@ -1,0 +1,16 @@
+import { apiClient } from "@/shared/api/client";
+
+import { epigramSchema, type Epigram } from "../model/schema";
+
+export interface UpdateEpigramRequest {
+  content?: string;
+  author?: string;
+  referenceTitle?: string;
+  referenceUrl?: string;
+  tags?: string[];
+}
+
+export async function updateEpigram(id: number, data: UpdateEpigramRequest): Promise<Epigram> {
+  const response = await apiClient.patch<unknown>(`/api/epigrams/${id}`, data);
+  return epigramSchema.parse(response.data);
+}

--- a/src/entities/epigram/api/useEpigrams.ts
+++ b/src/entities/epigram/api/useEpigrams.ts
@@ -6,6 +6,7 @@ import {
 
 import { apiClient } from "@/shared/api/client";
 
+import { buildEpigramListParams } from "./buildListParams";
 import { epigramListResponseSchema, type EpigramListResponse } from "../model/schema";
 
 interface UseEpigramsParams {
@@ -25,11 +26,7 @@ export function useEpigrams({
   return useInfiniteQuery({
     queryKey: ["epigrams", { limit, keyword, writerId }],
     queryFn: async ({ pageParam }) => {
-      const params = new URLSearchParams({ limit: String(limit) });
-      if (pageParam !== undefined) params.set("cursor", String(pageParam));
-      if (keyword) params.set("keyword", keyword);
-      if (writerId !== undefined) params.set("writerId", String(writerId));
-
+      const params = buildEpigramListParams({ limit, pageParam, keyword, writerId });
       const response = await apiClient.get<unknown>(`/api/epigrams?${params}`);
       return epigramListResponseSchema.parse(response.data);
     },

--- a/src/entities/epigram/api/useSearchEpigrams.ts
+++ b/src/entities/epigram/api/useSearchEpigrams.ts
@@ -6,6 +6,7 @@ import {
 
 import { apiClient } from "@/shared/api/client";
 
+import { buildEpigramListParams } from "./buildListParams";
 import { epigramListResponseSchema, type EpigramListResponse } from "../model/schema";
 
 interface UseSearchEpigramsParams {
@@ -23,9 +24,7 @@ export function useSearchEpigrams({
   return useInfiniteQuery({
     queryKey: ["search", "epigrams", keyword],
     queryFn: async ({ pageParam }) => {
-      const params = new URLSearchParams({ limit: String(limit), keyword });
-      if (pageParam !== undefined) params.set("cursor", String(pageParam));
-
+      const params = buildEpigramListParams({ limit, pageParam, keyword });
       const response = await apiClient.get<unknown>(`/api/epigrams?${params}`);
       return epigramListResponseSchema.parse(response.data);
     },

--- a/src/entities/epigram/index.ts
+++ b/src/entities/epigram/index.ts
@@ -11,4 +11,9 @@ export { useSearchEpigrams } from "./api/useSearchEpigrams";
 export { useTodayEpigram } from "./api/useTodayEpigram";
 export { useEpigramDetail } from "./api/useEpigramDetail";
 
+export { createEpigram } from "./api/createEpigram";
+export type { CreateEpigramRequest } from "./api/createEpigram";
+export { updateEpigram } from "./api/updateEpigram";
+export type { UpdateEpigramRequest } from "./api/updateEpigram";
+
 export { EpigramListCard } from "./ui/EpigramListCard";

--- a/src/entities/user/api/useMe.ts
+++ b/src/entities/user/api/useMe.ts
@@ -1,12 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { userQueryKeys } from "../model/queryKeys";
 import { type User } from "../model/schema";
 import { getMe } from "./user";
 
 export function useMe(): { user: User | null; isLoading: boolean } {
-  const { data, isLoading } = useQuery<User | null, Error>({
-    queryKey: ["me"],
-
+  const { data, isLoading } = useQuery({
+    queryKey: userQueryKeys.me(),
     queryFn: getMe,
     retry: false,
     // 헤더가 모든 라우트에 sticky로 마운트되므로, 전역 staleTime(60s)을 상속하면

--- a/src/entities/user/api/user.ts
+++ b/src/entities/user/api/user.ts
@@ -8,12 +8,12 @@ export interface UpdateMeBody {
 }
 
 export async function getMe(): Promise<User | null> {
-  const response = await apiClient.get<User | null>("/api/users/me");
+  const response = await apiClient.get<unknown>("/api/users/me");
   if (response.data === null) return null;
   return userSchema.parse(response.data);
 }
 
 export async function updateMe(body: UpdateMeBody): Promise<User> {
-  const response = await apiClient.patch("/api/users/me", body);
+  const response = await apiClient.patch<unknown>("/api/users/me", body);
   return userSchema.parse(response.data);
 }

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -2,6 +2,7 @@
 export { userSchema } from "./model/schema";
 export type { User } from "./model/schema";
 export type { UserWithEmail, SignUpResponse, SignInResponse } from "./model/types";
+export { userQueryKeys } from "./model/queryKeys";
 
 // api
 export { signUp, signIn, logout } from "./api/auth";

--- a/src/entities/user/model/queryKeys.ts
+++ b/src/entities/user/model/queryKeys.ts
@@ -1,0 +1,4 @@
+// 소비자(features/auth 등)가 stringly-typed `["me"]`를 반복하지 않도록 단일 진실 공급원으로 둔다.
+export const userQueryKeys = {
+  me: () => ["me"] as const,
+} as const;


### PR DESCRIPTION
## ✏️ 작업 내용

프로젝트 전체 simplify 리팩토링 스윕의 **Phase 4** — entities 레이어 4개 슬라이스를 격리 worktree에서 병렬 처리 후 단일 브랜치로 통합. entities는 FSD 최하위라 **breaking change 없이 export 추가만** 허용.

**변경된 슬라이스 (4개 커밋)**

| 슬라이스 | 핵심 변경 |
|---|---|
| `user` | `userQueryKeys.me()` 팩토리 신규 export, `useMe` 내부 팩토리 사용, axios 제네릭 `<User \| null>`→`<unknown>`로 zod 검증 전 타입 안전성 강화 |
| `emotion-log` | `fetchTodayEmotion`/`fetchMonthlyEmotions` 헬퍼 추출, WIP 영문 주석 → 한국어 "왜" 주석, `enabled: userId > 0` 가드 근거 명시 |
| `comment` | `buildCursorParams` 헬퍼로 4곳 URLSearchParams 보일러플레이트 통일, `commentQueryKeys` 6개 키 팩토리 신규 export (`all`/`recent`/`byEpigram`/`byEpigramWithParams`/`byUser`/`byUserWithParams`), 훅 내부도 팩토리 사용 |
| `epigram` | `buildEpigramListParams` 헬퍼로 3곳 중복 파라미터 조립 통일, `createEpigram`/`CreateEpigramRequest` 정식 export, `updateEpigram`/`UpdateEpigramRequest` 신규 함수 추가(후속 PR에서 `useEpigramEdit` 대체용) |

**공개 API 보장**

- 모든 기존 export(훅 이름·시그니처·타입)는 **변경 없이 유지**. 추가 export만 존재 → 소비자(features/widgets/views) 빌드 영향 없음
- 기존 훅 내부가 새 팩토리를 사용하되 배열 구조는 동일(deep-equal) → React Query 캐시 호환 유지

**검증**

- `npm run format` 통과
- `npm run lint` — 0 errors
- `npm run build` — 전체 라우트 정상 생성

## 🗨️ 논의 사항 (참고 사항)

**Phase 5 (shared) 이월 이슈**
- `buildCursorParams` (comment) + `buildEpigramListParams` (epigram) — 두 엔티티 모두 `limit` + `cursor` URLSearchParams 조립 패턴 공유. 필요 시 `shared/api/cursorPagination.ts`로 승격 검토
- `resolveAuthor` 공용 헬퍼 이관은 FSD 역방향(entities → features) 위반 이슈로 entities 내 추가 export 스킵. `AUTHOR_TYPE`/`AuthorType` enum을 `entities/epigram/model`로 이동하거나 `shared/lib`에 재배치하는 구조 변경 필요 — Phase 5 범위

**소비자 이전 후속 PR 필요** (이번 PR 스코프 밖)
- `"me"` stringly-typed 4곳 (`features/auth/api/logout.ts`·`LoginForm`·`GuestLoginButton`·`ProfileImageUpload`) → `userQueryKeys.me()`로 이전
- `["epigrams", id, "comments"]`·`["users", id, "comments"]` 하드코딩 (`features/comment-create`·`comment-edit`·`comment-delete`·`app/epigrams/page.tsx`) → `commentQueryKeys.byEpigram(id)`·`byUser(id)`·`recent({limit})`로 이전
- `features/epigram-edit/model/useEpigramEdit.ts`의 `apiClient.patch<Epigram>` 직접 호출 → 새로 export된 `updateEpigram()`으로 이전 (Zod 검증 추가 확보)

**별도 이슈 권장 (Breaking Change)**
- `entities/epigram` 상세 응답 schema의 `author: string` 평탄화 + `"알 수 없음"` 문자열 비교 — `EpigramAuthor` discriminated union으로 모델링하는 구조 개선 (Phase 4 스코프 내 breaking이라 보류)

## 기대효과

- entities 레이어의 **쿼리키 중앙화 기반 마련** — `userQueryKeys`·`commentQueryKeys` 팩토리 추가로 stringly-typed 중복 해소의 토대 완성. 소비자 이전은 후속 PR에서 타입 지원 받으며 안전하게 수행 가능
- **API 함수 보강** — 누락돼 있던 `updateEpigram`(+`CreateEpigramRequest`/`UpdateEpigramRequest` 타입) 정식 등록으로 features의 `apiClient` 직접 호출 해소 경로 확보
- **보일러플레이트 통일** — `buildCursorParams`/`buildEpigramListParams`로 URLSearchParams 조립 패턴을 슬라이스 내부에서 한 곳으로 수렴
- **타입 안전성 강화** — axios 제네릭을 `unknown`으로 변경해 zod 검증 전 타입 단언을 제거, 런타임 검증이 실제 타입 경계 역할 수행
- **Phase 5 작업 자산화** — cursor 페이지네이션·`resolveAuthor` 구조 변경 등 shared 레이어 리팩토링 타깃 명확화

Closes #339