### PR TITLE
refactor: shared 레이어 전면 simplify 리팩토링 (#341)

### DIFF
--- a/src/shared/ui/ErrorBoundary.tsx
+++ b/src/shared/ui/ErrorBoundary.tsx
@@ -31,10 +31,8 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     const { error } = this.state;
     const { fallback, children } = this.props;
 
-    if (error !== null) {
-      return typeof fallback === "function" ? fallback(error, this.reset) : fallback;
-    }
-
-    return children;
+    if (error === null) return children;
+    if (typeof fallback === "function") return fallback(error, this.reset);
+    return fallback;
   }
 }

--- a/src/shared/ui/Modal.tsx
+++ b/src/shared/ui/Modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { MouseEvent, ReactElement, ReactNode } from "react";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 import { Button } from "@/shared/ui/Button";
 
@@ -11,29 +11,22 @@ interface ModalProps {
 }
 
 export function Modal({ onClose, children }: ModalProps): ReactElement {
-  const previousFocusRef = useRef<HTMLElement | null>(null);
-  const mainContentRef = useRef<HTMLElement | null>(null);
-
   useEffect(() => {
-    previousFocusRef.current = document.activeElement as HTMLElement;
-    mainContentRef.current = document.getElementById("main-content");
+    const activeElement = document.activeElement;
+    const previousFocus = activeElement instanceof HTMLElement ? activeElement : null;
+    const mainContent = document.getElementById("main-content");
 
-    if (mainContentRef.current) {
-      mainContentRef.current.setAttribute("inert", "");
-    }
+    mainContent?.setAttribute("inert", "");
 
     return () => {
-      if (mainContentRef.current) {
-        mainContentRef.current.removeAttribute("inert");
-      }
-      previousFocusRef.current?.focus();
+      mainContent?.removeAttribute("inert");
+      previousFocus?.focus();
     };
   }, []);
 
   function handleBackdropClick(e: MouseEvent<HTMLDivElement>): void {
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
+    if (e.target !== e.currentTarget) return;
+    onClose();
   }
 
   return (


### PR DESCRIPTION
## ✏️ 작업 내용

프로젝트 전체 simplify 리팩토링 스윕의 **최종 Phase 5** — shared 레이어 6개 서브디렉토리(api/config/hooks/lib/types/ui)를 격리 worktree에서 동시 병렬 처리. shared는 전 레이어가 의존하는 최하위라 **breaking change 없이 기존 파일 내부 simplify만** 수행.

**변경된 서브디렉토리 (1개 커밋)**

| 서브디렉토리 | 결과 |
|---|---|
| `ui` | `ErrorBoundary.render()` 중첩 ternary → guard clause 3단계 early return, `Modal`의 불필요 `useRef` 2개 제거(effect 내 closure로 캡처), `document.activeElement as HTMLElement` 단언 → `instanceof HTMLElement` 타입 가드, `handleBackdropClick` guard clause |

**변경 없는 서브디렉토리 (이미 원칙 준수)**

- `api` — `apiClient`, `QueryProvider`, `uploadImage` 세 파일이 최근 PR들(#269/#287/#291)에서 이미 정밀 다듬어진 상태
- `config` — `backend.ts` 2줄만 존재, 이미 최소
- `hooks` — `useIntersectionObserver`/`useModal`/`useScrollToTop`/`useTagInput` 모두 guard clause·명시 반환 타입·단일 책임 충족
- `lib` — `clipboard.ts`/`cn.ts`/`date.ts`/`redirect.ts` 모두 시니어 수준
- `types` — `pagination.ts` 24줄, 제네릭 경계 명확하고 파생 타입 분리된 상태

**검증**

- `npm run format` 통과
- `npm run lint` — 0 errors
- `npm run build` — 전체 라우트 정상 생성

## 🗨️ 논의 사항 (참고 사항)

shared 레이어 제약(breaking change 금지, export 추가 최소화)으로 이번 PR에 포함하지 않은 **구조 개선 후보**들은 전부 별도 이슈로 분리 권장.

### Phase 1~4에서 이월된 "shared 추출/승격" 후보 (소비자 이전 동반)
- `LoadMoreButton` 패턴 4곳 중복 → `shared/ui/LoadMoreButton` 신설
- `ScrollToTopButton` 패턴 3곳 중복 → `shared/ui/ScrollToTopButton` 신설
- `animate-pulse rounded-2xl` 스켈레톤 패턴 → `shared/ui/SkeletonGrid` 신설
- `ErrorBoundary fallback` 래핑 패턴 → `shared/ui/SectionErrorBoundary` 래퍼
- `ConfirmModal` 호출 스타일 불일치(JSX vs 함수 호출) → JSX로 일관화
- `buildCursorParams`(comment) + `buildEpigramListParams`(epigram) → `shared/api/cursorPagination`
- `resolveAuthor` 공용 헬퍼 → `shared/lib` 또는 `entities/epigram/model`로 재배치 (`AUTHOR_TYPE` enum 이관 동반)
- `md:` vs `tablet:`/`desktop:`/`pc:` breakpoint 불일치 — 디자인 토큰/유틸 관점

### Phase 5 에이전트들이 추가로 발견한 구조 개선 후보
- **shared/api**: `uploadImage` 에러 메시지 vs 실제 allowed set 불일치, `server-only` 패키지 도입으로 서버 전용 import 강제, 환경 변수 부트타임 검증 레이어(`shared/config/env.ts`)
- **shared/hooks**: `useTagInput` 시그니처 재설계(외부 상태 주입 패턴 정리), `useIntersectionObserver` 옵션 객체 리터럴 전달 정리
- **shared/lib**: `clipboard.ts` fallback의 textarea 제거를 `try/finally`로 감싸 예외 시 누수 방지, `formatRelativeTime`의 ko-KR 로케일 고정(i18n 대비)
- **shared/types**: `PaginatedResponse`/`PaginatedSchemaOf` export의 실사용 여부 재검토 — 메이저 리팩토링 시 공개 API 정리
- **shared/ui**: Input/Textarea의 label+error+wrapper 중복 → `FormField` 래퍼, `id ?? label` fallback의 한글 label 접근성 버그 → `useId()` 도입, `Modal`의 ESC 키/focus trap 부재 → 접근성 개선, `RouteErrorFallback`의 인라인 버튼 스타일 vs `Button` variant 통합

### Phase 1~4 소비자 이전 후속 PR (여전히 유효)
- `"me"` stringly-typed 4곳 → `userQueryKeys.me()`
- `["epigrams", id, "comments"]`·`["users", id, "comments"]` 하드코딩 → `commentQueryKeys.*`
- `features/epigram-edit`의 `apiClient.patch<Epigram>` 직접 호출 → 신규 `updateEpigram()`

### 별도 fix 이슈 권장
- `features/user/ProfileImageUpload`의 unmount 중 `objectURL` cleanup 누락 (정확성 이슈)
- `entities/epigram` 상세 응답 `author: string` 평탄화 + `"알 수 없음"` 문자열 비교 → `EpigramAuthor` discriminated union 구조 개선 (breaking)

## 기대효과

- shared 레이어의 **기존 코드 품질 확인 및 잔여 개선** — `Modal`/`ErrorBoundary` 두 핵심 컴포넌트의 중첩 ternary·불필요 ref·위험한 단언 제거로 안정성 향상, 나머지 5개 서브디렉토리는 이미 깨끗함을 공식 확인
- **전체 simplify 스윕 완료** — Phase 1(views) → Phase 2(widgets) → Phase 3(features) → Phase 4(entities) → Phase 5(shared) 5단계 캐스케이드 마무리
- **후속 작업 로드맵 완비** — 이번 PR 기간 동안 각 Phase 에이전트들이 스코프 바깥에서 발견한 구조 개선 후보 20+건이 논의 사항에 집대성되어 이후 작업 계획 가능

Closes #341