### PR TITLE
refactor: 헌법 1.1.0 적용 — 현상 정당화 주석 일괄 정리 및 연관 코드 재리팩토링 (#345)

### DIFF
--- a/src/app/epigrams/page.tsx
+++ b/src/app/epigrams/page.tsx
@@ -5,10 +5,8 @@ import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query
 import { fetchRecentCommentsPageServer } from "@/entities/comment/api/server";
 import { fetchEpigramsPageServer, fetchTodayEpigramServer } from "@/entities/epigram/api/server";
 import { EpigramsPage } from "@/views/epigrams";
-
-// Must match the values used in EpigramFeed and RecentComments widgets
-const FEED_PAGE_SIZE = 5;
-const COMMENTS_PAGE_SIZE = 4;
+import { FEED_PAGE_SIZE } from "@/widgets/epigram-feed";
+import { RECENT_COMMENTS_PAGE_SIZE } from "@/widgets/comment-section";
 
 export default async function Page(): Promise<ReactElement> {
   const queryClient = new QueryClient({
@@ -35,10 +33,10 @@ export default async function Page(): Promise<ReactElement> {
       .catch(() => {}),
     queryClient
       .prefetchInfiniteQuery({
-        queryKey: ["comments", { limit: COMMENTS_PAGE_SIZE }],
+        queryKey: ["comments", { limit: RECENT_COMMENTS_PAGE_SIZE }],
         queryFn: ({ pageParam }) =>
           fetchRecentCommentsPageServer({
-            limit: COMMENTS_PAGE_SIZE,
+            limit: RECENT_COMMENTS_PAGE_SIZE,
             pageParam: pageParam as number | undefined,
           }),
         initialPageParam: undefined as number | undefined,

--- a/src/app/feeds/page.tsx
+++ b/src/app/feeds/page.tsx
@@ -3,10 +3,7 @@ import type { ReactElement } from "react";
 import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
 
 import { fetchEpigramsPageServer } from "@/entities/epigram/api/server";
-import { FeedsPage } from "@/views/feeds";
-
-// Must match FEEDS_PAGE_SIZE in FeedsPage
-const FEEDS_PAGE_SIZE = 10;
+import { FeedsPage, FEEDS_PAGE_SIZE } from "@/views/feeds";
 
 export default async function FeedsRoute(): Promise<ReactElement> {
   const queryClient = new QueryClient({

--- a/src/entities/emotion-log/api/useTodayEmotion.ts
+++ b/src/entities/emotion-log/api/useTodayEmotion.ts
@@ -8,9 +8,7 @@ async function fetchTodayEmotion(userId: number): Promise<EmotionLog | null> {
   const response = await apiClient.get<unknown>("/api/emotionLogs/today", {
     params: { userId },
   });
-  // 백엔드는 오늘 기록이 없을 때 null/빈 응답을 반환하므로 스키마 파싱 전에 걸러낸다.
-  if (response.data == null || typeof response.data !== "object") return null;
-  return emotionLogSchema.parse(response.data);
+  return emotionLogSchema.nullable().parse(response.data ?? null);
 }
 
 export function useTodayEmotion(userId: number): UseQueryResult<EmotionLog | null, Error> {

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -1,10 +1,8 @@
-// model
 export { userSchema } from "./model/schema";
 export type { User } from "./model/schema";
 export type { UserWithEmail, SignUpResponse, SignInResponse } from "./model/types";
 export { userQueryKeys } from "./model/queryKeys";
 
-// api
 export { signUp, signIn, logout } from "./api/auth";
 export type { SignUpBody, SignInBody } from "./api/auth";
 export { signInKakao } from "./api/kakao";

--- a/src/entities/user/model/queryKeys.ts
+++ b/src/entities/user/model/queryKeys.ts
@@ -1,4 +1,3 @@
-// 소비자(features/auth 등)가 stringly-typed `["me"]`를 반복하지 않도록 단일 진실 공급원으로 둔다.
 export const userQueryKeys = {
   me: () => ["me"] as const,
 } as const;

--- a/src/features/auth/ui/ProfileImageUpload.tsx
+++ b/src/features/auth/ui/ProfileImageUpload.tsx
@@ -45,7 +45,6 @@ export function ProfileImageUpload({
     try {
       const imageUrl = await uploadImage(file);
       await updateMe({ image: imageUrl });
-      // Clear preview so displayUrl falls back to the new currentImageUrl from parent
       setPreviewUrl(null);
       URL.revokeObjectURL(objectUrl);
       // Non-blocking: UI already shows the cleared preview

--- a/src/features/emotion-select/model/useEmotionSelect.ts
+++ b/src/features/emotion-select/model/useEmotionSelect.ts
@@ -37,7 +37,6 @@ export function useEmotionSelect(): UseEmotionSelectReturn {
       return { previous };
     },
     onError: (_err, _emotion, context) => {
-      // 실패 시 이전 값으로 롤백
       queryClient.setQueryData(todayKey, context?.previous);
     },
     onSuccess: () => {

--- a/src/features/epigram-search/model/useSearch.ts
+++ b/src/features/epigram-search/model/useSearch.ts
@@ -19,7 +19,6 @@ export function useSearch(): UseSearchResult {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  // URL이 단일 진실 공급원 — 별도 상태 없이 직접 파생
   const activeKeyword = searchParams.get("keyword") ?? "";
 
   const [inputValue, setInputValue] = useState(activeKeyword);

--- a/src/views/feeds/index.ts
+++ b/src/views/feeds/index.ts
@@ -1,1 +1,1 @@
-export { FeedsPage } from "./ui/FeedsPage";
+export { FeedsPage, FEEDS_PAGE_SIZE } from "./ui/FeedsPage";

--- a/src/views/feeds/ui/FeedsPage.tsx
+++ b/src/views/feeds/ui/FeedsPage.tsx
@@ -11,7 +11,7 @@ import { EmptyState } from "@/shared/ui/EmptyState";
 import { ErrorBoundary } from "@/shared/ui/ErrorBoundary";
 import { SectionErrorFallback } from "@/shared/ui/SectionErrorFallback";
 
-const FEEDS_PAGE_SIZE = 10;
+export const FEEDS_PAGE_SIZE = 10;
 
 function FeedsSkeleton(): ReactElement {
   return (

--- a/src/views/mypage/ui/MypagePage.tsx
+++ b/src/views/mypage/ui/MypagePage.tsx
@@ -34,7 +34,6 @@ function formatTodayLabel(date: Date): string {
   return `${year}.${month}.${day}`;
 }
 
-// 모듈 로드 시점에 한 번만 계산 — 세션 중 날짜는 바뀌지 않는다
 const TODAY_LABEL = formatTodayLabel(new Date());
 
 function ProfileSkeleton(): ReactElement {

--- a/src/widgets/comment-section/index.ts
+++ b/src/widgets/comment-section/index.ts
@@ -1,2 +1,5 @@
-export { RecentComments } from "./ui/RecentComments";
+export {
+  RecentComments,
+  COMMENTS_PAGE_SIZE as RECENT_COMMENTS_PAGE_SIZE,
+} from "./ui/RecentComments";
 export { CommentSection } from "./ui/CommentSection";

--- a/src/widgets/comment-section/ui/RecentComments.tsx
+++ b/src/widgets/comment-section/ui/RecentComments.tsx
@@ -11,7 +11,7 @@ import { formatRelativeTime } from "@/shared/lib/date";
 
 import type { Comment } from "@/entities/comment";
 
-const COMMENTS_PAGE_SIZE = 4;
+export const COMMENTS_PAGE_SIZE = 4;
 
 interface CommentItemProps {
   comment: Comment;

--- a/src/widgets/epigram-feed/index.ts
+++ b/src/widgets/epigram-feed/index.ts
@@ -1,1 +1,1 @@
-export { EpigramFeed } from "./ui/EpigramFeed";
+export { EpigramFeed, FEED_PAGE_SIZE } from "./ui/EpigramFeed";

--- a/src/widgets/epigram-feed/ui/EpigramFeed.tsx
+++ b/src/widgets/epigram-feed/ui/EpigramFeed.tsx
@@ -10,7 +10,7 @@ import { EmptyState } from "@/shared/ui/EmptyState";
 import { ErrorBoundary } from "@/shared/ui/ErrorBoundary";
 import { SectionErrorFallback } from "@/shared/ui/SectionErrorFallback";
 
-const FEED_PAGE_SIZE = 5;
+export const FEED_PAGE_SIZE = 5;
 const FEED_SKELETON_COUNT = 3;
 
 interface FeedSectionProps {

--- a/src/widgets/mypage-activity/ui/MypageActivity.tsx
+++ b/src/widgets/mypage-activity/ui/MypageActivity.tsx
@@ -29,8 +29,6 @@ interface MypageActivityProps {
   userId: number;
 }
 
-// ─── Load More Button ─────────────────────────────────────────────────────────
-
 interface LoadMoreButtonProps {
   isFetchingNextPage: boolean;
   label: string;
@@ -56,8 +54,6 @@ function LoadMoreButton({
     </div>
   );
 }
-
-// ─── Comment Card ─────────────────────────────────────────────────────────────
 
 const DEFAULT_AVATAR = "/icon/035-smiling face.png";
 
@@ -113,8 +109,6 @@ function MyCommentItem({ comment, epigramId, userId }: MyCommentItemProps): Reac
   );
 }
 
-// ─── Epigram List ─────────────────────────────────────────────────────────────
-
 interface MyEpigramListProps {
   userId: number;
   onTotalCount: (count: number) => void;
@@ -155,8 +149,6 @@ function MyEpigramList({ userId, onTotalCount }: MyEpigramListProps): ReactEleme
     </div>
   );
 }
-
-// ─── Comment List ─────────────────────────────────────────────────────────────
 
 interface MyCommentListProps {
   userId: number;
@@ -204,8 +196,6 @@ function MyCommentList({ userId, onTotalCount }: MyCommentListProps): ReactEleme
   );
 }
 
-// ─── Tabbed Section ───────────────────────────────────────────────────────────
-
 interface TabbedSectionProps {
   userId: number;
 }
@@ -251,8 +241,6 @@ function TabbedSection({ userId }: TabbedSectionProps): ReactElement {
     </div>
   );
 }
-
-// ─── MypageActivity ───────────────────────────────────────────────────────────
 
 export function MypageActivity({ userId }: MypageActivityProps): ReactElement {
   const { data: monthlyLogs = [] } = useMonthlyEmotions({


### PR DESCRIPTION
## ✏️ 작업 내용

헌법 1.1.0(#344 머지) 개정으로 확립된 "주석은 최후 수단, 기존 주석도 제거 가능성부터 의심" 원칙에 따라 `src/` 전체 73개 주석을 감사한 결과.

**1차: 코드 개선 + 주석 제거 (커밋 1·2)**

- **`entities/emotion-log/api/useTodayEmotion.ts`** (커밋 1)
  - 기존: 수동 타입 가드 + "백엔드가 null/빈 응답 반환" 주석으로 현상을 정당화
  - 변경: `emotionLogSchema.nullable().parse(response.data ?? null)` 한 줄로 대체. "null 허용"이 스키마에 선언적으로 드러나고 가드·주석 모두 제거
- **`app/feeds/page.tsx` + `app/epigrams/page.tsx`** (커밋 2)
  - 기존: `// Must match FEEDS_PAGE_SIZE in FeedsPage` 같은 주석이 두 곳 하드코딩을 정당화
  - 변경: `views/feeds`(FEEDS_PAGE_SIZE), `widgets/epigram-feed`(FEED_PAGE_SIZE), `widgets/comment-section`(RECENT_COMMENTS_PAGE_SIZE로 재노출 — 내부 CommentSection의 동명 상수와 충돌 방지) 퍼블릭 API에서 공유 상수 export. `app/...` 라우트들이 import해 중복·주석 모두 제거

**2차: 현상 서술/섹션 라벨 주석 제거 (커밋 3)**

헌법 기준으로 "코드가 이미 드러내는 것을 설명"하는 주석 7건 삭제. 코드 변경 없음.

- `entities/user/model/queryKeys.ts` — 파일명/변수명이 이미 의도 담음
- `entities/user/index.ts` — `// model` `// api` 섹션 라벨
- `features/emotion-select/useEmotionSelect.ts` — "실패 시 이전 값으로 롤백" (`setQueryData(todayKey, context?.previous)` 자체로 명백)
- `features/epigram-search/useSearch.ts` — "URL이 단일 진실 공급원" (다음 줄 `searchParams.get(...)` 자체로 드러남)
- `views/mypage/MypagePage.tsx` — "모듈 로드 시점에 한 번만 계산" (모듈 스코프 JS 기본 동작)
- `features/auth/ProfileImageUpload.tsx` — "Clear preview so displayUrl..." (`setPreviewUrl(null)`로 의도 드러남)
- `widgets/mypage-activity/MypageActivity.tsx` — 6개 섹션 구분 라벨 (`// ─── Load More Button ───` 등, 각 함수/interface 이름이 이미 섹션 역할)

**유지 (실제 비자명 제약)**

`middleware.ts`의 캐시·라우터 매칭 정책, `useMe`의 `staleTime: Infinity` 근거, BFF 프록시(`api/[...path]/route.ts`) 동작, swagger↔실제 응답 불일치(`useTodayEpigram`), `QueryProvider`의 browser/server 분기, `uploadImage`의 Content-Type·ASCII 제약, React `split(regex)` 동작, DOM 이벤트 타입 단언 방어, `router.refresh()` RSC 캐시 근거, `startTransition` + SSR 회피 등은 코드만으론 재구성 불가한 외부 제약이라 유지.

**검증**

- `npm run format` 통과
- `npm run lint` — 0 errors
- `npm run build` — 전체 라우트 정상 생성

## 🗨️ 논의 사항 (참고 사항)

**감사 결과 통계**
- 전체: 73개 주석 / 32개 파일
- 제거+코드 개선: 2건
- 제거만: 12건 (6개 MypageActivity 섹션 라벨 포함)
- 유지: 59건

**이번 시도에서 배운 점**
- 자동화 simplify 스윕은 구문 레벨(중첩 삼항/`any`/네이밍)은 잘 잡지만, schema↔imperative 검증 중복 같은 의미론적 설계 중복은 놓침. 주석이 오히려 bad pattern을 정당화·보호하는 anchor로 작용
- 헌법 1.1.0에 "주석 최후 수단" 메타 규칙을 추가했고 이번 감사가 그 규칙의 첫 실사용 사례

**추가 고려 사항 (이번 PR에는 미반영)**
- `RECENT_COMMENTS_PAGE_SIZE` 이름: widget 이름(`RecentComments`)에서 파생. 향후 `CommentSection`의 내부 상수도 이 명명 규칙으로 재정비(`DETAIL_COMMENTS_PAGE_SIZE` 같은 의미) 가능 — 별도 스코프

## 기대효과

- 코드가 "무엇을 하는지"를 이미 드러내는데도 주석으로 보강되던 **현상 서술** 12건 제거 → 파일당 signal-to-noise 개선
- `useTodayEmotion`의 **런타임 검증과 스키마 정의 중복**을 스키마 계약으로 단일화 → null 처리가 타입 수준에서 선언적으로 명시됨
- 페이지 크기 같은 **SSR↔CSR 계약 상수**가 단일 소스로 통합 → 실수로 한쪽만 바뀌어 prefetch miss가 발생할 위험 제거
- 헌법 1.1.0의 **주석 메타 규칙이 실제로 작동함을 사례로 확립** — 향후 리팩토링 태스크에서 기존 "왜" 주석을 의심 대상으로 다루는 관행 정착

Closes #345