### PR TITLE
fix: useTodayEmotion 빈 문자열 응답 처리 — `??` → `||` (#347)

### DIFF
--- a/src/entities/emotion-log/api/useTodayEmotion.ts
+++ b/src/entities/emotion-log/api/useTodayEmotion.ts
@@ -8,7 +8,8 @@ async function fetchTodayEmotion(userId: number): Promise<EmotionLog | null> {
   const response = await apiClient.get<unknown>("/api/emotionLogs/today", {
     params: { userId },
   });
-  return emotionLogSchema.nullable().parse(response.data ?? null);
+  // axios는 204 No Content 응답 시 response.data를 빈 문자열로 해석 — `??`(null/undefined만)이 아니라 `||`(falsy 전체)로 정규화해야 nullable()이 처리 가능.
+  return emotionLogSchema.nullable().parse(response.data || null);
 }
 
 export function useTodayEmotion(userId: number): UseQueryResult<EmotionLog | null, Error> {


### PR DESCRIPTION
## ✏️ 작업 내용

PR #346 첫 커밋(`fix: useTodayEmotion schema nullable 적용`)의 회귀 fix.

`response.data ?? null` → `response.data || null` 한 글자 변경.

```diff
- return emotionLogSchema.nullable().parse(response.data ?? null);
+ return emotionLogSchema.nullable().parse(response.data || null);
```

## 🗨️ 논의 사항 (참고 사항)

**원인**

`??`(nullish coalescing)는 **`null`·`undefined`만** 대체한다. `""`(빈 문자열), `0`, `false` 같은 falsy 값은 그대로 왼쪽 값이 유지됨.

```js
"" ?? null   // ""  — 빈 문자열은 nullish 아님
"" || null   // null
```

axios는 204 No Content 응답을 받으면 `response.data`를 `""`로 해석한다. 백엔드가 "오늘 감정 기록 없음" 케이스에 204를 반환하므로 `response.data ?? null`은 여전히 `""` — 이후 `schema.nullable().parse("")`가 빈 문자열 때문에 실패 → 예외 throw → React Query error state → `/epigrams`·`/mypage` 컴포넌트 트리 깨짐.

`||`는 falsy 전체를 대체하므로 `""`도 `null`로 정규화되고, `nullable()`이 문제없이 통과.

**왜 PR #346 빌드 테스트에서 안 걸렸나**

- `npm run build`는 타입체크 + 정적 페이지 생성만. 런타임 API 응답 시뮬레이션 아님
- 204 No Content는 실제 서버 동작으로만 재현. 유닛 테스트 없이 로컬 dev 서버 검증이 누락됨

**재발 방지**

- 이번 "왜 주석"은 비자명 외부 제약(axios 204 동작 + `??`/`||` 차이)을 설명하므로 헌법 1.1.0 기준으로도 유지 대상 — 코드만으론 재구성 불가
- 추가 방어책(장기): `shared/api/client` 레벨에서 204 응답을 `null`로 정규화하는 interceptor 도입하면 각 API 함수가 빈 문자열을 방어할 필요 없어짐 — 별도 이슈로 제안

## 기대효과

- `/epigrams`, `/mypage` 런타임 에러 즉시 해소
- `??`/`||` 차이라는 실제 버그 원인이 주석으로 명시되어 향후 유사 패턴 작성 시 참고 가능
- PR #346의 schema nullable 방향성은 유지하면서 한 문자 변경으로 회귀 해결

Closes #347