### PR TITLE
fix: 댓글 생성·수정 후 마이페이지 댓글 목록 캐시 무효화 (#349)

### DIFF
--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -1,7 +1,7 @@
 export { writerSchema, commentSchema, commentListResponseSchema } from "./model/schema";
 export type { Writer, Comment, CommentListResponse } from "./model/schema";
 
-export { commentQueryKeys } from "./model/queryKeys";
+export { commentQueryKeys, matchesCommentQuery } from "./model/queryKeys";
 
 export { useRecentComments } from "./api/useRecentComments";
 export { useEpigramComments } from "./api/useEpigramComments";

--- a/src/entities/comment/model/queryKeys.ts
+++ b/src/entities/comment/model/queryKeys.ts
@@ -1,10 +1,3 @@
-/**
- * comment 엔티티 쿼리키 팩토리.
- *
- * features/comment-create·comment-edit·comment-delete 등 소비자들이
- * 에피그램·유저별 댓글 캐시를 일관된 키로 무효화할 수 있도록 한 곳에 모은다.
- * 하드코딩된 `["epigrams", id, "comments"]` 반복 대신 이 팩토리를 사용한다.
- */
 export const commentQueryKeys = {
   all: ["comments"] as const,
   recent: (params: { limit: number }) => ["comments", params] as const,
@@ -15,3 +8,11 @@ export const commentQueryKeys = {
   byUserWithParams: (userId: number, params: { limit: number }) =>
     ["users", userId, "comments", params] as const,
 } as const;
+
+export function matchesCommentQuery(queryKey: readonly unknown[]): boolean {
+  const [prefix, , third] = queryKey;
+  if (prefix === "comments") return true;
+  if (prefix === "epigrams" && third === "comments") return true;
+  if (prefix === "users" && third === "comments") return true;
+  return false;
+}

--- a/src/features/comment-create/model/useCommentCreate.ts
+++ b/src/features/comment-create/model/useCommentCreate.ts
@@ -6,7 +6,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "@/shared/api/client";
 
-import type { Comment } from "@/entities/comment";
+import { matchesCommentQuery, type Comment } from "@/entities/comment";
 
 interface CreateCommentBody {
   epigramId: number;
@@ -43,7 +43,9 @@ export function useCommentCreate(epigramId: number): UseCommentCreateReturn {
   } = useMutation({
     mutationFn: createComment,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["epigrams", epigramId, "comments"] });
+      queryClient.invalidateQueries({
+        predicate: (query) => matchesCommentQuery(query.queryKey),
+      });
       setContent("");
       setIsPrivate(false);
     },

--- a/src/features/comment-edit/model/useCommentEdit.ts
+++ b/src/features/comment-edit/model/useCommentEdit.ts
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "@/shared/api/client";
-import type { Comment } from "@/entities/comment";
+import { matchesCommentQuery, type Comment } from "@/entities/comment";
 
 interface UpdateCommentBody {
   content: string;
@@ -51,7 +51,9 @@ export function useCommentEdit({
     mutationFn: (body: UpdateCommentBody) =>
       apiClient.patch<Comment>(`/api/comments/${commentId}`, body).then((res) => res.data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["epigrams", epigramId, "comments"] });
+      queryClient.invalidateQueries({
+        predicate: (query) => matchesCommentQuery(query.queryKey),
+      });
       onCancel();
     },
   });


### PR DESCRIPTION
## ✏️ 작업 내용

댓글 생성·수정 후 마이페이지 내 댓글 목록이 실시간 반영 안 되던 회귀 fix.

- `entities/comment`에 `matchesCommentQuery(queryKey)` predicate 헬퍼 **추가 export**
  - byEpigram(`["epigrams", id, "comments"]`) / byUser(`["users", id, "comments"]`) / recent(`["comments", ...]`) 모든 comment 관련 쿼리 매칭
- `useCommentCreate`·`useCommentEdit`의 `onSuccess`에서 `predicate: (q) => matchesCommentQuery(q.queryKey)`로 무효화 범위 확대
- 기존: `["epigrams", epigramId, "comments"]`만 무효화 → **byUser(마이페이지) 누락**이 회귀의 원인

## 🗨️ 논의 사항 (참고 사항)

**원인 추적**
- Phase 3(`#337`) features 리팩토링에서 `useCommentCreate` 내부 구조를 정리했으나 기존 `onSuccess`의 byEpigram-만-무효화 로직은 그대로 유지
- 이후 마이페이지(`/mypage`)의 `useMyComments(userId)`가 byUser 키를 쓰기 시작했으나 create/edit 훅은 그 키를 모름
- `useCommentDelete`는 이미 `userId?` 파라미터를 받아 두 키를 모두 무효화하고 있어 삭제는 정상 반영 — create/edit만 빠짐

**접근 방식**
- 훅 시그니처(`useCommentCreate(epigramId)`, `useCommentEdit({...})`)는 유지 — `userId` 파라미터를 새로 요구하면 모든 호출부를 건드려야 함
- 대신 `entities/comment` 레이어에 predicate 헬퍼를 추가 export하고 훅 내부에서만 사용 → 호출부 변경 0, 무효화 범위만 확장

**후속**
- `useCommentDelete`도 같은 `matchesCommentQuery`로 통일하면 현재 누락된 `recent` 피드(랜딩 최근 댓글)까지 함께 갱신 가능 — 별도 이슈
- 장기적으로 entities 계층에서 "모든 comment mutate 공통 invalidation" 래퍼 훅을 제공하는 방안 검토 가능

## 기대효과

- 댓글 작성·수정 시 마이페이지 내 댓글 목록이 즉시 반영
- predicate 한 곳(`matchesCommentQuery`)에 정의되어 향후 comment 쿼리키 구조가 바뀌어도 수정점 단일화

Closes #349