### PR TITLE
fix: 회원가입 직후 me 캐시 세팅 및 router.refresh (#351)

### DIFF
--- a/src/features/auth/ui/SignUpForm.tsx
+++ b/src/features/auth/ui/SignUpForm.tsx
@@ -3,6 +3,7 @@
 import type { ReactElement } from "react";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
@@ -15,6 +16,7 @@ import { signUpSchema, type SignUpFormValues } from "../model/signUpSchema";
 
 export function SignUpForm(): ReactElement {
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const {
     register,
@@ -28,7 +30,11 @@ export function SignUpForm(): ReactElement {
 
   async function onSubmit(data: SignUpFormValues): Promise<void> {
     try {
-      await signUp(data);
+      const { user } = await signUp(data);
+      queryClient.setQueryData(["me"], user);
+      // router.refresh() 없이 push하면 캐시된 미인증 RSC 페이로드가 서빙되어
+      // 미들웨어가 다시 /login으로 리다이렉트한다.
+      router.refresh();
       router.push("/");
     } catch (error) {
       if (isAxiosError(error) && error.response?.status === 500) {

--- a/src/features/comment-edit/model/useCommentEdit.ts
+++ b/src/features/comment-edit/model/useCommentEdit.ts
@@ -34,7 +34,6 @@ interface UseCommentEditReturn {
 
 export function useCommentEdit({
   commentId,
-  epigramId,
   initialContent,
   initialIsPrivate,
   onCancel,


### PR DESCRIPTION
## ✏️ 작업 내용

회원가입 완료 후 헤더 유저 아이콘이 즉시 반영되지 않던 문제 fix.

`LoginForm`이 수행하는 3단계(`setQueryData(["me"], user)` + `router.refresh()` + `router.push()`)를 `SignUpForm`의 onSubmit에도 동일하게 적용.

```diff
- await signUp(data);
- router.push("/");
+ const { user } = await signUp(data);
+ queryClient.setQueryData(["me"], user);
+ router.refresh();
+ router.push("/");
```

## 🗨️ 논의 사항 (참고 사항)

**원인**
- 기존 `SignUpForm`은 `signUp(data)` 호출만 하고 반환값을 버린 채 바로 `router.push("/")` 수행
- 이동 후 헤더가 `useMe` 쿼리를 새로 fetch할 때까지 게스트 상태로 렌더링됨
- `router.refresh()` 누락으로 이전 미인증 RSC 페이로드가 재사용될 여지도 있었음

**접근 방식**
- `signUp` API는 이미 `SignUpResponse { user }`를 반환 — signIn과 동일 형태라 LoginForm 패턴 그대로 복사 가능
- `["me"]` raw 쿼리키는 현재 LoginForm과 동일하게 유지(공용 `userQueryKeys.me()` 팩토리 이전은 별도 스코프)

**재발 방지**
- 향후 OAuth 콜백 등 "로그인 성공 후 me 캐시 세팅 + refresh + push" 3단계가 반복되면 `shared/lib/auth` 등에 `applySignInSideEffects(user, redirect)` 공용 훅/함수로 통합하는 방안 검토 (별도 이슈)

## 기대효과

- 회원가입 완료 즉시 헤더·네비게이션이 로그인 상태로 전환
- 로그인·회원가입 플로우의 post-auth 사이드 이펙트가 동일 패턴으로 일관

Closes #351