### PR TITLE
fix: 댓글 삭제 캐시 무효화 통일 + 회원가입 리다이렉트 (#353, #354)

### DIFF
--- a/src/features/auth/ui/SignUpForm.tsx
+++ b/src/features/auth/ui/SignUpForm.tsx
@@ -35,7 +35,7 @@ export function SignUpForm(): ReactElement {
       // router.refresh() 없이 push하면 캐시된 미인증 RSC 페이로드가 서빙되어
       // 미들웨어가 다시 /login으로 리다이렉트한다.
       router.refresh();
-      router.push("/");
+      router.push("/epigrams");
     } catch (error) {
       if (isAxiosError(error) && error.response?.status === 500) {
         setError("nickname", { message: "이미 사용 중인 닉네임입니다." });

--- a/src/features/comment-delete/model/useCommentDelete.tsx
+++ b/src/features/comment-delete/model/useCommentDelete.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import { matchesCommentQuery } from "@/entities/comment";
 import { apiClient } from "@/shared/api/client";
 import { useModal } from "@/shared/hooks/useModal";
 import { ConfirmModal } from "@/shared/ui/Modal";
@@ -13,8 +14,8 @@ interface UseCommentDeleteReturn {
 
 export function useCommentDelete(
   commentId: number,
-  epigramId: number,
-  userId?: number
+  _epigramId: number,
+  _userId?: number
 ): UseCommentDeleteReturn {
   const queryClient = useQueryClient();
   const { open } = useModal();
@@ -23,7 +24,11 @@ export function useCommentDelete(
     mutationFn: async (): Promise<void> => {
       await apiClient.delete(`/api/comments/${commentId}`);
     },
-    onSuccess: () => invalidateCommentCaches(queryClient, epigramId, userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        predicate: (query) => matchesCommentQuery(query.queryKey),
+      });
+    },
   });
 
   function handleDeleteClick(): void {
@@ -39,20 +44,4 @@ export function useCommentDelete(
   }
 
   return { handleDeleteClick, isDeleting };
-}
-
-async function invalidateCommentCaches(
-  queryClient: QueryClient,
-  epigramId: number,
-  userId?: number
-): Promise<void> {
-  const tasks: Array<Promise<void>> = [
-    queryClient.invalidateQueries({ queryKey: ["epigrams", epigramId, "comments"] }),
-  ];
-
-  if (userId !== undefined) {
-    tasks.push(queryClient.invalidateQueries({ queryKey: ["users", userId, "comments"] }));
-  }
-
-  await Promise.all(tasks);
 }


### PR DESCRIPTION
## ✏️ 작업 내용

**1. 댓글 삭제 캐시 무효화 predicate 통일 (#353)**

`useCommentDelete`가 기존에 `userId !== undefined`일 때만 `["users", userId, "comments"]`를 invalidate하던 로컬 헬퍼(`invalidateCommentCaches`) 제거. PR #350에서 create/edit이 쓰기 시작한 **`matchesCommentQuery` predicate**를 이 훅에도 적용해 byEpigram / byUser / recent 전부 일관되게 무효화.

- 로컬 헬퍼 + `QueryClient` type import 제거
- `epigramId` / `userId` 파라미터는 호출부 시그니처 유지 차원에서 남기되 `_` 접두사로 표시(lint unused-args 규칙 통과)

**2. 회원가입 성공 후 리다이렉트 경로 변경 (#354)**

`SignUpForm`의 성공 push 경로를 `/` → `/epigrams`로 변경. 가입 직후 곧바로 피드로 진입.

## 🗨️ 논의 사항 (참고 사항)

- PR #350 본문의 후속 TODO("useCommentDelete도 같은 predicate로 통일") 소진
- `useCommentDelete` 파라미터 단순화(`_epigramId`/`_userId` 제거 + 호출부 수정)는 호출부 2곳까지 건드려야 해 breaking 범위가 커서 이번 PR 범위 밖으로 둠 — 별도 이슈 후보
- `LoginForm`은 `searchParams.get("redirect")` 기반으로 원래 위치 복귀를 처리하고 있어 변경 불필요

## 기대효과

- 댓글 삭제 시 마이페이지 내 댓글 목록이 즉시 갱신
- 댓글 생성·수정·삭제 세 훅이 동일한 `matchesCommentQuery` 무효화 경로를 사용 → 향후 쿼리키 구조 변경 시 수정점 단일화
- 회원가입 후 첫 화면이 피드가 되어 빈 랜딩 페이지 경유 단계 제거

Closes #353
Closes #354