### PR TITLE
fix: 상세페이지 댓글/에피그램 케밥 드롭다운 디자인 정리 (#356)

### DIFF
--- a/src/views/epigram-detail/ui/EpigramDetailPage.tsx
+++ b/src/views/epigram-detail/ui/EpigramDetailPage.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState, type ReactElement } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
-import { ArrowLeft, ExternalLink, MoreVertical, Share2 } from "lucide-react";
+import { ArrowLeft, ExternalLink, MoreVertical, Pencil, Share2, Trash2 } from "lucide-react";
 
 import { useEpigramDetail } from "@/entities/epigram";
 import { useMe } from "@/entities/user";
@@ -51,19 +51,26 @@ function ActionMenu({ epigramId, onDelete }: ActionMenuProps): ReactElement {
       {isOpen && (
         <>
           <div className="fixed inset-0 z-10" onClick={() => setIsOpen(false)} />
-          <div className="absolute right-0 top-8 z-20 min-w-[100px] rounded-xl border border-line-200 bg-white py-1 shadow-lg">
+          <div
+            role="menu"
+            className="absolute right-0 top-9 z-20 flex w-28 flex-col overflow-hidden rounded-xl border border-line-200 bg-white py-0 shadow-lg"
+          >
             <button
               type="button"
+              role="menuitem"
               onClick={handleEdit}
-              className="w-full px-4 py-2 text-left text-sm text-black-700 hover:bg-blue-50"
+              className="flex items-center justify-center gap-2 whitespace-nowrap px-4 pr-5 py-3 text-left text-sm text-black-500 transition-colors hover:bg-blue-50 hover:text-black-900"
             >
+              <Pencil size={14} aria-hidden="true" />
               수정
             </button>
             <button
               type="button"
+              role="menuitem"
               onClick={handleDelete}
-              className="w-full px-4 py-2 text-left text-sm text-red-500 hover:bg-red-50"
+              className="flex items-center justify-center gap-2 whitespace-nowrap px-4 pr-5 py-3 text-left text-sm text-error transition-colors hover:bg-red-50"
             >
+              <Trash2 size={14} aria-hidden="true" />
               삭제
             </button>
           </div>

--- a/src/widgets/comment-section/ui/CommentSection.tsx
+++ b/src/widgets/comment-section/ui/CommentSection.tsx
@@ -115,21 +115,26 @@ function CommentItem({ comment, epigramId, currentUserId }: CommentItemProps): R
               </button>
 
               {isMenuOpen && (
-                <div className="absolute right-0 top-7 z-10 flex flex-col rounded-xl border border-line-200 bg-white py-1 shadow-lg">
+                <div
+                  role="menu"
+                  className="absolute right-0 top-8 z-10 flex w-28 flex-col overflow-hidden rounded-xl border border-line-200 bg-white py-0 shadow-lg"
+                >
                   <button
                     type="button"
+                    role="menuitem"
                     onClick={handleEditStart}
-                    className="flex items-center gap-2 px-4 py-2 text-sm text-black-500 transition-colors hover:bg-blue-50 hover:text-black-900"
+                    className="flex items-center justify-center gap-2 whitespace-nowrap px-4 pr-5 py-2 text-left text-sm text-black-500 transition-colors hover:bg-blue-50 hover:text-black-900"
                   >
-                    <Pencil size={12} />
+                    <Pencil size={14} aria-hidden="true" />
                     수정
                   </button>
                   <button
                     type="button"
+                    role="menuitem"
                     onClick={handleDelete}
-                    className="flex items-center gap-2 px-4 py-2 text-sm text-error transition-colors hover:bg-red-50"
+                    className="flex items-center justify-center gap-2 whitespace-nowrap px-4 pr-5 py-2 text-left text-sm text-error transition-colors hover:bg-red-50"
                   >
-                    <Trash2 size={12} />
+                    <Trash2 size={14} aria-hidden="true" />
                     삭제
                   </button>
                 </div>


### PR DESCRIPTION
## ✏️ 작업 내용

- 상세페이지 **댓글 케밥** 드롭다운 스타일 정리 ([CommentSection.tsx](src/widgets/comment-section/ui/CommentSection.tsx))
  - 고정 너비 `w-28` + `whitespace-nowrap` 적용 → 좁은 컨테이너에서 한글이 세로로 끊기던 문제 해결
  - 아이콘 사이즈 12 → 14, 아이템 `justify-center` 정렬로 시각 균형 맞춤
  - `role="menu"` / `role="menuitem"` 접근성 속성 추가
- 상세페이지 **에피그램 케밥** 드롭다운 스타일 정리 ([EpigramDetailPage.tsx](src/views/epigram-detail/ui/EpigramDetailPage.tsx))
  - `Pencil` · `Trash2` 아이콘 추가 → 댓글 드롭다운과 톤 통일
  - 동일한 `w-28`, `whitespace-nowrap`, `overflow-hidden`, role 속성 적용
  - 버튼 offset `top-8` → `top-9`로 조정해 위치 쏠림 완화

## 🗨️ 논의 사항 (참고 사항)

- 두 드롭다운 모두 동일한 구조로 맞췄지만, 재사용 가능한 공통 `DropdownMenu` 컴포넌트로 추출할지는 추후 다른 케밥 UI가 추가될 때 판단.

## 기대효과

- 좁은 뷰포트에서도 한글이 세로로 끊기지 않음
- 댓글/에피그램 드롭다운이 동일한 시각 언어로 통일되어 브랜드 일관성 확보

Closes #356