### PR TITLE
fix: 로그인 후 redirect 라우터 캐시 stale 문제 (#358)

### DIFF
--- a/src/app/oauth/callback/kakao/page.tsx
+++ b/src/app/oauth/callback/kakao/page.tsx
@@ -30,6 +30,7 @@ function KakaoCallbackHandler(): null {
         const savedRedirect = sessionStorage.getItem(SESSION_REDIRECT_KEY);
         sessionStorage.removeItem(SESSION_REDIRECT_KEY);
         router.replace(getSafeRedirect(savedRedirect));
+        router.refresh();
       })
       .catch(() => router.replace("/login"));
   }, [router, searchParams, queryClient]);

--- a/src/features/auth/ui/GuestLoginButton.tsx
+++ b/src/features/auth/ui/GuestLoginButton.tsx
@@ -28,8 +28,8 @@ export function GuestLoginButton(): ReactElement {
     try {
       const { user } = await signIn(GUEST_CREDENTIALS);
       queryClient.setQueryData(["me"], user);
+      router.replace(getSafeRedirect(searchParams.get("redirect")));
       router.refresh();
-      router.push(getSafeRedirect(searchParams.get("redirect")));
     } catch {
       setError("게스트 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.");
     } finally {

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -34,10 +34,8 @@ export function LoginForm(): ReactElement {
     try {
       const { user } = await signIn(data);
       queryClient.setQueryData(["me"], user);
-      // router.refresh() 없이 push하면 캐시된 미인증 RSC 페이로드가 서빙되어
-      // 미들웨어가 다시 /login으로 리다이렉트한다.
+      router.replace(getSafeRedirect(searchParams.get("redirect")));
       router.refresh();
-      router.push(getSafeRedirect(searchParams.get("redirect")));
     } catch {
       const message = "이메일 혹은 비밀번호를 확인해주세요.";
       setError("email", { message });


### PR DESCRIPTION
## ✏️ 작업 내용

비로그인 상태에서 보호 경로(`/epigrams/[id]` 등) 카드 클릭 → `/login?redirect=...`로 이동, 로그인 후 원래 경로로 리다이렉트가 **간헐적으로 실패**하는 문제 수정.

원인은 비로그인 시 `<Link>` prefetch가 미들웨어 307 리다이렉트를 받아 그 결과가 **클라이언트 라우터 캐시(JS 메모리)에 stale 엔트리로 박히는 것**. 로그인 후 `router.push(redirect)`가 그 캐시를 먼저 조회해 다시 `/login`으로 튕김. HTTP `Cache-Control`은 라우터 캐시는 못 막음.

수정 전:
```ts
router.refresh();   // /login 자체만 refresh (의미 없음)
router.push(redirect);  // stale 캐시 사용 → 실패 가능
```

수정 후 (Wine 프로젝트의 검증된 패턴):
```ts
router.replace(redirect);  // destination으로 먼저 이동
router.refresh();          // 현재(=destination) 라우트 캐시 무효화 → fresh RSC
```

변경 파일:
- `src/features/auth/ui/LoginForm.tsx` — 일반 로그인
- `src/features/auth/ui/GuestLoginButton.tsx` — 게스트 로그인
- `src/app/oauth/callback/kakao/page.tsx` — 카카오 OAuth 콜백 (`router.refresh()` 누락 보강)

## 🗨️ 논의 사항 (참고 사항)

- 라우터 캐시는 브라우저 JS 메모리에 저장되며 HTTP 헤더로 제어 불가. `Cache-Control: no-store`는 브라우저/CDN 캐시는 막지만 라우터 캐시는 못 막음
- 더 강한 방어책으로 미들웨어가 prefetch 요청(`next-router-prefetch` 헤더)을 감지해 401로 끊어 캐시 오염 자체를 막는 방법도 있음. 이번 PR로 잡히지 않으면 추가 이슈로 진행

## 기대효과

- 비로그인 → 보호 경로 카드 클릭 → 로그인 → 원래 상세 페이지로 안정적으로 이동
- 일반/게스트/카카오 3가지 로그인 경로 모두 일관된 패턴 적용
- 불필요해진 "router.refresh() 없이 push하면…" 주석 제거로 코드 명확성 향상

Closes #358