### PR TITLE
fix: 비로그인 prefetch 요청에 401 응답해 라우터 캐시 오염 차단 (#360)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,9 +12,6 @@ function isProtectedPath(pathname: string): boolean {
 // 로그인 상태에서 접근하면 홈으로 리다이렉트
 const AUTH_ONLY_PATHS = ["/login", "/signup", "/oauth/signup/kakao"];
 
-// 미들웨어 리다이렉트 응답이 브라우저/Next 클라이언트 캐시에 남으면
-// 로그인 후에도 보호 경로로 이동했을 때 캐시된 "→ /login" 응답이 재사용되어
-// 사용자가 다시 로그인 페이지로 튕긴다. no-store로 캐시 자체를 차단한다.
 function redirectWithoutCache(url: URL): NextResponse {
   const response = NextResponse.redirect(url);
   response.headers.set("Cache-Control", "no-store");
@@ -27,6 +24,12 @@ export function middleware(request: NextRequest): NextResponse | undefined {
   const isLoggedIn = request.cookies.has("accessToken") || request.cookies.has("refreshToken");
 
   if (isProtectedPath(pathname) && !isLoggedIn) {
+    // prefetch 요청에 307을 돌려주면 그 결과가 클라이언트 라우터 캐시에 박혀,
+    // 로그인 후에도 stale "→ /login" 엔트리가 재사용되어 사용자가 튕긴다.
+    // 401은 라우터 캐시에 저장되지 않으므로 prefetch만 끊어 캐시 오염을 막는다.
+    if (request.headers.get("next-router-prefetch")) {
+      return new NextResponse(null, { status: 401 });
+    }
     const loginUrl = new URL("/login", request.url);
     loginUrl.searchParams.set("redirect", pathname);
     return redirectWithoutCache(loginUrl);


### PR DESCRIPTION
## ✏️ 작업 내용

#358 / #359 에서 적용한 클라이언트 측 수정(`router.replace → router.refresh` 순서 변경)만으로는 **배포 환경에서 로그인 후 원래 페이지로 이동하지 못하는 문제가 재현**되어, 근본 원인인 **prefetch 응답의 라우터 캐시 오염**을 미들웨어 차원에서 차단.

### 변경

`src/middleware.ts` — 보호 경로 + 비로그인 분기에서 `next-router-prefetch` 헤더를 감지하면 307 리다이렉트 대신 **401**을 반환:

```ts
if (isProtectedPath(pathname) && !isLoggedIn) {
  if (request.headers.get("next-router-prefetch")) {
    return new NextResponse(null, { status: 401 });
  }
  // 실제 navigation 요청은 기존대로 /login?redirect=...
  ...
}
```

### 동작

| 요청 종류 | 헤더 | 응답 | 라우터 캐시 |
|---|---|---|---|
| `<Link>` prefetch (백그라운드) | `next-router-prefetch: 1` | **401** | 저장 안 됨 |
| 사용자 클릭 (실제 navigation) | (없음) | 307 → `/login?redirect=...` | (해당 없음) |
| 로그인 상태 | — | 분기 자체에 안 들어옴 | 정상 prefetch 동작 |

비로그인 시 보호 경로 prefetch는 어차피 사용자에게 보여줄 수 없는 콘텐츠라 401로 끊어도 손실 없음. 로그인 상태의 prefetch는 영향 없음.

함께 정리: `redirectWithoutCache` 위에 달려 있던 잘못된 정보 주석 제거 (`no-store`는 HTTP/CDN 캐시는 막지만 라우터 캐시는 못 막음 — 진짜 원인은 prefetch 응답 자체).

## 🗨️ 논의 사항 (참고 사항)

- 라우터 캐시는 브라우저 JS 메모리에 저장되며 응답 콘텐츠를 그대로 캐시함. HTTP 헤더 제어 불가
- 401은 정상 navigation 흐름이 아닌 에러 응답이므로 라우터 캐시가 저장하지 않음 (Next.js 내부 동작)
- 헤더명은 Next.js 14+ App Router 기준 `next-router-prefetch`. 향후 Next 메이저 업데이트 시 변경 가능성 모니터링 필요

## 기대효과

- 배포 환경에서도 비로그인 → 보호 경로 카드 클릭 → 로그인 → 원래 상세 페이지로 안정적 이동
- 라우터 캐시 오염 자체를 발생 시점에 차단해 클라이언트 측 우회(`router.refresh()` 등)에 의존하지 않음
- prefetch 응답이 실제로는 의미 없는 리다이렉트인 경우를 줄여 불필요한 네트워크 트래픽도 감소

Closes #360