### PR TITLE
fix: 로그인 후 redirect를 window.location 풀 리로드로 단순화 (#362)

### DIFF
--- a/src/app/oauth/callback/kakao/page.tsx
+++ b/src/app/oauth/callback/kakao/page.tsx
@@ -5,15 +5,12 @@ import { Suspense, useEffect } from "react";
 
 import { useRouter, useSearchParams } from "next/navigation";
 
-import { useQueryClient } from "@tanstack/react-query";
-
 import { signInKakao } from "@/entities/user";
 import { getSafeRedirect, SESSION_REDIRECT_KEY } from "@/shared/lib";
 
 function KakaoCallbackHandler(): null {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const queryClient = useQueryClient();
 
   useEffect(() => {
     const code = searchParams.get("code");
@@ -25,15 +22,13 @@ function KakaoCallbackHandler(): null {
     const redirectUri = `${window.location.origin}/oauth/callback/kakao`;
 
     signInKakao({ token: code, redirectUri })
-      .then(({ user }) => {
-        queryClient.setQueryData(["me"], user);
+      .then(() => {
         const savedRedirect = sessionStorage.getItem(SESSION_REDIRECT_KEY);
         sessionStorage.removeItem(SESSION_REDIRECT_KEY);
-        router.replace(getSafeRedirect(savedRedirect));
-        router.refresh();
+        window.location.replace(getSafeRedirect(savedRedirect));
       })
       .catch(() => router.replace("/login"));
-  }, [router, searchParams, queryClient]);
+  }, [router, searchParams]);
 
   return null;
 }

--- a/src/features/auth/ui/GuestLoginButton.tsx
+++ b/src/features/auth/ui/GuestLoginButton.tsx
@@ -2,9 +2,7 @@
 
 import { type ReactElement, useState } from "react";
 
-import { useRouter, useSearchParams } from "next/navigation";
-
-import { useQueryClient } from "@tanstack/react-query";
+import { useSearchParams } from "next/navigation";
 
 import { signIn } from "@/entities/user";
 import { getSafeRedirect } from "@/shared/lib";
@@ -16,9 +14,7 @@ const GUEST_CREDENTIALS = {
 } as const;
 
 export function GuestLoginButton(): ReactElement {
-  const router = useRouter();
   const searchParams = useSearchParams();
-  const queryClient = useQueryClient();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -26,13 +22,10 @@ export function GuestLoginButton(): ReactElement {
     setIsLoading(true);
     setError(null);
     try {
-      const { user } = await signIn(GUEST_CREDENTIALS);
-      queryClient.setQueryData(["me"], user);
-      router.replace(getSafeRedirect(searchParams.get("redirect")));
-      router.refresh();
+      await signIn(GUEST_CREDENTIALS);
+      window.location.replace(getSafeRedirect(searchParams.get("redirect")));
     } catch {
       setError("게스트 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.");
-    } finally {
       setIsLoading(false);
     }
   }

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -3,10 +3,8 @@
 import type { ReactElement } from "react";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
-
-import { useQueryClient } from "@tanstack/react-query";
 
 import { signIn } from "@/entities/user";
 import { getSafeRedirect } from "@/shared/lib";
@@ -16,9 +14,7 @@ import { Input } from "@/shared/ui/Input";
 import { loginSchema, type LoginFormValues } from "../model/loginSchema";
 
 export function LoginForm(): ReactElement {
-  const router = useRouter();
   const searchParams = useSearchParams();
-  const queryClient = useQueryClient();
 
   const {
     register,
@@ -32,10 +28,8 @@ export function LoginForm(): ReactElement {
 
   async function onSubmit(data: LoginFormValues): Promise<void> {
     try {
-      const { user } = await signIn(data);
-      queryClient.setQueryData(["me"], user);
-      router.replace(getSafeRedirect(searchParams.get("redirect")));
-      router.refresh();
+      await signIn(data);
+      window.location.replace(getSafeRedirect(searchParams.get("redirect")));
     } catch {
       const message = "이메일 혹은 비밀번호를 확인해주세요.";
       setError("email", { message });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,12 +24,6 @@ export function middleware(request: NextRequest): NextResponse | undefined {
   const isLoggedIn = request.cookies.has("accessToken") || request.cookies.has("refreshToken");
 
   if (isProtectedPath(pathname) && !isLoggedIn) {
-    // prefetch 요청에 307을 돌려주면 그 결과가 클라이언트 라우터 캐시에 박혀,
-    // 로그인 후에도 stale "→ /login" 엔트리가 재사용되어 사용자가 튕긴다.
-    // 401은 라우터 캐시에 저장되지 않으므로 prefetch만 끊어 캐시 오염을 막는다.
-    if (request.headers.get("next-router-prefetch")) {
-      return new NextResponse(null, { status: 401 });
-    }
     const loginUrl = new URL("/login", request.url);
     loginUrl.searchParams.set("redirect", pathname);
     return redirectWithoutCache(loginUrl);


### PR DESCRIPTION
## ✏️ 작업 내용

#358/#359 → #360/#361 두 차례 시도에도 **배포 환경에서 비로그인 → 보호 경로 → 로그인 후 원래 페이지로 이동 실패가 계속 재현**되어, SPA 전환을 포기하고 풀 페이지 리로드 방식으로 통일.

### 변경

**`src/features/auth/ui/LoginForm.tsx`**
```ts
// before
const { user } = await signIn(data);
queryClient.setQueryData(["me"], user);
router.replace(getSafeRedirect(searchParams.get("redirect")));
router.refresh();

// after
await signIn(data);
window.location.replace(getSafeRedirect(searchParams.get("redirect")));
```

**`src/features/auth/ui/GuestLoginButton.tsx`** — 동일 패턴 적용

**`src/app/oauth/callback/kakao/page.tsx`** — 성공 시 `window.location.replace`, 실패 시는 그대로 `router.replace("/login")` (실패 케이스는 캐시 이슈 없음)

**`src/middleware.ts`** — #361에서 추가했던 prefetch 401 분기 제거. 풀 리로드 방식에선 라우터 캐시 의존이 사라져 prefetch 차단도 불필요.

함께 정리:
- 풀 리로드로 React 트리가 재초기화되므로 `queryClient.setQueryData(["me"], user)`는 의미 없어 제거
- 더 이상 필요 없는 `useRouter`, `useQueryClient` 등 import 정리

## 🗨️ 논의 사항 (참고 사항)

- SPA 전환 손실은 비용이지만 로그인 직후 **1회성 전환**이라 사용자 체감 영향 작음. 브라우저는 메인 JS 번들을 캐시하고 있어 풀 리로드도 빠름
- 라우터 캐시가 공개 API로 통제 가능해지거나 Next.js가 prefetch 응답 처리를 명세화하면 다시 SPA 전환으로 복원 검토 가능
- 로그아웃·signup 후 redirect는 영향 범위 밖이라 별도 이슈로 (현재 동작 유지)

## 기대효과

- 배포 환경에서도 비로그인 → 보호 경로 카드 클릭 → 로그인 → 원래 상세로 **결정적으로** 이동
- 라우터 캐시 의존이 사라져 디버깅·검증 비용 감소
- 코드 단순화: -33 lines, +9 lines

Closes #362